### PR TITLE
New Mode Team-Tournament 

### DIFF
--- a/TournamentsEnhanced.csproj
+++ b/TournamentsEnhanced.csproj
@@ -71,13 +71,46 @@
       <HintPath>$(LibPath)/ModLib.Definitions.dll</HintPath>
       <PrivateAssets>all</PrivateAssets>
     </Reference>
+    <Reference Include="SandBox">
+      <HintPath>$(BannerlordModulesPath)SandBox/bin/Win64_Shipping_Client/SandBox.dll</HintPath>
+    </Reference>
+    <Reference Include="SandBox.GauntletUI">
+      <HintPath>$(BannerlordModulesPath)SandBox/bin/Win64_Shipping_Client/SandBox.GauntletUI.dll</HintPath>
+    </Reference>
+    <Reference Include="SandBox.View">
+      <HintPath>$(BannerlordModulesPath)SandBox/bin/Win64_Shipping_Client/SandBox.View.dll</HintPath>
+    </Reference>
+    <Reference Include="SandBox.ViewModelCollection">
+      <HintPath>$(BannerlordModulesPath)SandBox/bin/Win64_Shipping_Client/SandBox.ViewModelCollection.dll</HintPath>
+    </Reference>
     <Reference Include="TaleWorlds.CampaignSystem">
       <HintPath>$(BannerlordDLLPath)/TaleWorlds.CampaignSystem.dll</HintPath>
       <PrivateAssets>none</PrivateAssets>
     </Reference>
+    <Reference Include="TaleWorlds.CampaignSystem.ViewModelCollection">
+      <HintPath>$(BannerlordDLLPath)/TaleWorlds.CampaignSystem.ViewModelCollection.dll</HintPath>
+    </Reference>
     <Reference Include="TaleWorlds.Core">
       <HintPath>$(BannerlordDLLPath)/TaleWorlds.Core.dll</HintPath>
       <PrivateAssets>none</PrivateAssets>
+    </Reference>
+    <Reference Include="TaleWorlds.Core.ViewModelCollection">
+      <HintPath>$(BannerlordDLLPath)/TaleWorlds.Core.ViewModelCollection.dll</HintPath>
+    </Reference>
+    <Reference Include="TaleWorlds.DotNet">
+      <HintPath>$(BannerlordDLLPath)/TaleWorlds.DotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="TaleWorlds.Engine">
+      <HintPath>$(BannerlordDLLPath)/TaleWorlds.Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="TaleWorlds.Engine.GauntletUI">
+      <HintPath>$(BannerlordDLLPath)/TaleWorlds.Engine.GauntletUI.dll</HintPath>
+    </Reference>
+    <Reference Include="TaleWorlds.GauntletUI">
+      <HintPath>$(BannerlordDLLPath)/TaleWorlds.GauntletUI.dll</HintPath>
+    </Reference>
+    <Reference Include="TaleWorlds.GauntletUI.Data">
+      <HintPath>$(BannerlordDLLPath)/TaleWorlds.GauntletUI.Data.dll</HintPath>
     </Reference>
     <Reference Include="TaleWorlds.InputSystem">
       <HintPath>$(BannerlordDLLPath)/TaleWorlds.InputSystem.dll</HintPath>
@@ -95,9 +128,18 @@
       <HintPath>$(BannerlordDLLPath)/TaleWorlds.MountAndBlade.dll</HintPath>
       <PrivateAssets>none</PrivateAssets>
     </Reference>
+    <Reference Include="TaleWorlds.MountAndBlade.View">
+      <HintPath>$(BannerlordModulesPath)/Native/bin/Win64_Shipping_Client/TaleWorlds.MountAndBlade.View.dll</HintPath>
+    </Reference>
+    <Reference Include="TaleWorlds.MountAndBlade.ViewModelCollection">
+      <HintPath>$(BannerlordDLLPath)/TaleWorlds.MountAndBlade.ViewModelCollection.dll</HintPath>
+    </Reference>
     <Reference Include="TaleWorlds.ObjectSystem">
       <HintPath>$(BannerlordDLLPath)/TaleWorlds.ObjectSystem.dll</HintPath>
       <PrivateAssets>none</PrivateAssets>
+    </Reference>
+    <Reference Include="TaleWorlds.PlayerServices">
+      <HintPath>$(BannerlordDLLPath)/TaleWorlds.PlayerServices.dll</HintPath>
     </Reference>
     <Reference Include="TaleWorlds.SaveSystem">
       <HintPath>$(BannerlordDLLPath)/TaleWorlds.SaveSystem.dll</HintPath>

--- a/src/BehaviorBase.cs
+++ b/src/BehaviorBase.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Helpers;
@@ -11,16 +10,14 @@ using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
 using TaleWorlds.ObjectSystem;
+using TournamentsEnhanced.TeamTournament.Menu;
 
 namespace TournamentsEnhanced
 {
   class BehaviorBase : EncounterGameMenuBehavior
   {
     public static int weeksSinceHost = 1;
-
     private const int MAX_TOURNAMENTS = 2;
-
-    private Random _random = new Random();
 
     public bool PrizeSelectCondition(MenuCallbackArgs args)
     {
@@ -152,7 +149,8 @@ namespace TournamentsEnhanced
     {
       //add option to the menu
       campaignGameStarter.AddGameMenuOption("town_arena", "host_tournament", "Host a tournament in your honor (" +
-        TournamentsEnhancedSettings.Instance.TournamentCost.ToString() + "{GOLD_ICON})", new GameMenuOption.OnConditionDelegate(game_menu_town_arena_host_tournament_condition),
+        TournamentsEnhancedSettings.Instance.TournamentCost.ToString() + "{GOLD_ICON})",
+        new GameMenuOption.OnConditionDelegate(game_menu_town_arena_host_tournament_condition),
         new GameMenuOption.OnConsequenceDelegate(game_menu_town_arena_host_tournament_consequence), false, 1, false);
 
       campaignGameStarter.AddGameMenuOption("town_arena", "select_prize", "Select your prize",
@@ -167,11 +165,19 @@ namespace TournamentsEnhanced
       {
         campaignGameStarter.AddGameMenuOption("town_arena", "test_add_tournament_game", "Add Tournament",
           new GameMenuOption.OnConditionDelegate(this.AddTournamentCondition),
-          new GameMenuOption.OnConsequenceDelegate(this.AddTournamentConsequence), false, 1, true);
+          new GameMenuOption.OnConsequenceDelegate(this.AddTournamentConsequence), false, 2, true);
 
         campaignGameStarter.AddGameMenuOption("town_arena", "test_resolve_tournament_game", "Resolve Tournament",
            new GameMenuOption.OnConditionDelegate(this.ResolveTournamentCondition),
-           new GameMenuOption.OnConsequenceDelegate(this.ResolveTournamentConsequence), false, 1, true);
+           new GameMenuOption.OnConsequenceDelegate(this.ResolveTournamentConsequence), false, 3, true);
+      }
+
+      if (TournamentsEnhancedSettings.Instance.EnableTeamTournaments)
+      {
+        var teamTournamentMenu = new TeamTournamentTeamSelectionMenu();
+        campaignGameStarter.AddGameMenuOption("town_arena", "participate_as_team", "Join as Team",
+          new GameMenuOption.OnConditionDelegate(teamTournamentMenu.GameMenuSelectRosterCondition),
+          new GameMenuOption.OnConsequenceDelegate(teamTournamentMenu.GameMenuSelectRosterConsequence), false, 7, false);
       }
     }
 

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -105,5 +105,9 @@ namespace TournamentsEnhanced
     [SettingProperty("Enable Create/Resolve Tournaments", "Adds town menu options for creating and resolving tournaments")]
     [SettingPropertyGroup("Debug")]
     public bool DebugCreateAndResolveTournaments { get; set; } = false;
+
+    [SettingProperty("Enable Team Tournaments", "Adds an option for joining and participating in the tournaments as a team.")]
+    [SettingPropertyGroup("Tournaments")]
+    public bool EnableTeamTournaments { get; set; } = true;
   }
 }

--- a/src/TeamTournament/Menu/GauntletMenuManageTeamSelection.cs
+++ b/src/TeamTournament/Menu/GauntletMenuManageTeamSelection.cs
@@ -1,0 +1,83 @@
+﻿using SandBox.View.Map;
+using SandBox.View.Menu;
+using TaleWorlds.Engine.GauntletUI;
+using TaleWorlds.Engine.Screens;
+using TaleWorlds.GauntletUI.Data;
+using TaleWorlds.InputSystem;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade.View.Missions;
+using TournamentsEnhanced.TeamTournament.Menu.ViewModels;
+
+namespace TournamentsEnhanced.TeamTournament.Menu
+{
+  [OverrideView(typeof(MenuManageTeamSelection))]
+  public class GauntletMenuManageTeamSelection : MenuView
+  {
+    public GauntletMenuManageTeamSelection(TournamentKB tkb)
+    {
+      this._tournamentKB = tkb;
+    }
+
+    protected override void OnInitialize()
+    {
+      base.OnInitialize();
+      this._dataSource = new ManageTeamSelectionVM(this._tournamentKB)
+      {
+        IsEnabled = true
+      };
+      this._gauntletLayer = new GauntletLayer(205, "GauntletLayer")
+      {
+        Name = "MenuManageHideoutTroops"
+      };
+      this._gauntletLayer.InputRestrictions.SetInputRestrictions(true, InputUsageMask.All);
+      this._gauntletLayer.Input.RegisterHotKeyCategory(HotKeyManager.GetCategory("GenericCampaignPanelsGameKeyCategory"));
+      this._movie = this._gauntletLayer.LoadMovie("GameMenuManageHideoutTroops", this._dataSource);
+      this._gauntletLayer.IsFocusLayer = true;
+      ScreenManager.TrySetFocus(this._gauntletLayer);
+      base.MenuViewContext.AddLayer(this._gauntletLayer);
+      MapScreen mapScreen = ScreenManager.TopScreen as MapScreen;
+      if (mapScreen != null)
+        mapScreen.IsInHideoutTroopManage = true;
+    }
+
+    protected override void OnFinalize()
+    {
+      this._gauntletLayer.IsFocusLayer = false;
+      ScreenManager.TryLoseFocus(this._gauntletLayer);
+      this._dataSource.OnFinalize();
+      this._dataSource = null;
+      this._gauntletLayer.ReleaseMovie(this._movie);
+      base.MenuViewContext.RemoveLayer(this._gauntletLayer);
+      this._movie = null;
+      this._gauntletLayer = null;
+      MapScreen mapScreen = ScreenManager.TopScreen as MapScreen;
+      if (mapScreen != null)
+        mapScreen.IsInHideoutTroopManage = false;
+
+      base.OnFinalize();
+    }
+
+    protected override void OnFrameTick(float dt)
+    {
+      base.OnFrameTick(dt);
+      if (this._gauntletLayer.Input.IsHotKeyPressed("Exit"))
+      {
+        this._dataSource.IsEnabled = false;
+      }
+      if (!this._dataSource.IsEnabled)
+      {
+        base.MenuViewContext.CloseManageHideoutTroops();
+      }
+    }
+
+    private readonly TournamentKB _tournamentKB;
+    private GauntletLayer _gauntletLayer;
+    private ManageTeamSelectionVM _dataSource;
+    private GauntletMovie _movie;
+  }
+
+  // Gauntlet Dummy
+  public class MenuManageTeamSelection : MenuView
+  {
+  }
+}

--- a/src/TeamTournament/Menu/TeamTournamentTeamSelectionMenu.cs
+++ b/src/TeamTournament/Menu/TeamTournamentTeamSelectionMenu.cs
@@ -1,0 +1,53 @@
+﻿using Helpers;
+using SandBox.View.Menu;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.GameMenus;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using TournamentsEnhanced.extensions;
+
+namespace TournamentsEnhanced.TeamTournament.Menu
+{
+  internal class TeamTournamentTeamSelectionMenu
+  {
+    public bool GameMenuSelectRosterCondition(MenuCallbackArgs args)
+    {
+      bool canPlayerDo = Campaign.Current.Models.SettlementAccessModel.CanMainHeroDoSettlementAction(
+          Settlement.CurrentSettlement,
+          SettlementAccessModel.SettlementAction.JoinTournament,
+          out bool shouldBeDisabled,
+          out TextObject disabledText);
+
+      args.optionLeaveType = GameMenuOption.LeaveType.ManageHideoutTroops;
+
+      // if this is a team tournament, activate
+      shouldBeDisabled &= TournamentKB.Current != null;
+      canPlayerDo &= TournamentKB.Current != null;
+
+      if (shouldBeDisabled || disabledText.ToString().IsStringNoneOrEmpty())
+        disabledText = new TextObject($"Roster can only be selected for team tournaments.");
+
+      return MenuHelper.SetOptionProperties(args, canPlayerDo, shouldBeDisabled, disabledText);
+    }
+
+    public void GameMenuSelectRosterConsequence(MenuCallbackArgs args)
+    {
+      var menuViewContext = args.MenuContext.Handler as MenuViewContext;
+      if (menuViewContext != null)
+        HandleRosterSelection(menuViewContext);
+    }
+
+    private void HandleRosterSelection(MenuViewContext menuViewContext)
+    {
+      var manageTroopsMenu = menuViewContext.AddMenuView<MenuManageTeamSelection>(new object[]
+      {
+          TournamentKB.Current
+      });
+
+      // override _menuManageHideoutTroops inside MenuViewContext to fake that we opened it
+      // needed later for closing it
+      // reset inside MenuViewContext::CloseManageHideoutTroops
+      menuViewContext.SetPrivateFieldValue("_menuManageHideoutTroops", manageTroopsMenu);
+    }
+  }
+}

--- a/src/TeamTournament/Menu/ViewModels/ManageTeamSelectionVM.cs
+++ b/src/TeamTournament/Menu/ViewModels/ManageTeamSelectionVM.cs
@@ -1,0 +1,292 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.GameMenus;
+using TaleWorlds.CampaignSystem.ViewModelCollection.GameMenu.ManageHideoutTroops;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+
+namespace TournamentsEnhanced.TeamTournament.Menu.ViewModels
+{
+  internal class ManageTeamSelectionVM : ViewModel
+  {
+    public ManageTeamSelectionVM(TournamentKB tkb)
+    {
+      this._tournamentKB = tkb;
+      this._maxSelectableTroopCount = _tournamentKB.TeamSize;
+      this.InitializeAvailableSelection();
+      this.RefreshValues();
+      this.OnCurrentSelectedAmountChange();
+    }
+
+    public override void RefreshValues()
+    {
+      base.RefreshValues();
+      this.TitleText = new TextObject("Select Team").ToString();
+      this.DoneText = GameTexts.FindText("str_done").ToString();
+      this.CancelText = GameTexts.FindText("str_cancel").ToString();
+      this.CurrentSelectedAmountTitle = new TextObject("Selected Tournament Team").ToString();
+    }
+
+    private bool CanBeSelectedByHero(CharacterObject character)
+    {
+      var isSameSettlement = character.HeroObject.CurrentSettlement == Hero.MainHero.CurrentSettlement;
+      if (!isSameSettlement) return false;
+
+      var isSameClan = Hero.MainHero.Clan == character.HeroObject.Clan;
+      if (isSameClan) return true;
+
+      var isSameAlliance = Hero.MainHero.MapFaction == character.HeroObject.MapFaction;
+      if (isSameAlliance) return true;
+
+      return Hero.MainHero.AllLivingRelatedHeroes().Contains(character.HeroObject);
+    }
+
+    private void InitializeAvailableSelection()
+    {
+      this.Troops = new MBBindingList<ManageHideoutTroopItemVM>();
+      this._currentTotalSelectedTroopCount = 0;
+      var availableForSelection = TroopRoster.CreateDummyTroopRoster();
+
+      // we add everyone is settlement that is relevant to the selection list
+      var selectableChars = Settlement.CurrentSettlement.LocationComplex
+        .GetListOfCharacters()
+        .Where(x => x != null && x.Character.IsHero && CanBeSelectedByHero(x.Character))
+        .Select(sel => sel.Character);
+
+      var flattenTroopRoster = new FlattenedTroopRoster(0);
+
+      // add the main hero at the top
+      flattenTroopRoster.Add(Hero.MainHero.CharacterObject, 1, 0);
+
+      foreach (var character in selectableChars)
+      {
+        flattenTroopRoster.Add(character, 1, 0);
+      }
+      availableForSelection.Add(flattenTroopRoster); // add every other hero afterwards
+
+      // now also add own trops in party roster
+      var partyTroops = MobileParty.MainParty.MemberRoster.ToFlattenedRoster().Where(x => !x.Troop.IsHero);
+      availableForSelection.Add(partyTroops);
+
+      foreach (var member in availableForSelection.GetTroopRoster())
+      {
+        var troopItemVM = new ManageHideoutTroopItemVM(member,
+          new Action<ManageHideoutTroopItemVM>(this.OnAddCount),
+          new Action<ManageHideoutTroopItemVM>(this.OnRemoveCount));
+
+        troopItemVM.IsLocked = member.Character.IsPlayerCharacter || (member.Number - member.WoundedNumber <= 0);
+        this.Troops.Add(troopItemVM);
+
+        if (member.Character.IsPlayerCharacter)
+        {
+          troopItemVM.CurrentAmount = 1;
+          this._currentTotalSelectedTroopCount += 1;
+        }
+      }
+    }
+
+    private void OnRemoveCount(ManageHideoutTroopItemVM troopItem)
+    {
+      if (troopItem.CurrentAmount > 0)
+      {
+        troopItem.CurrentAmount--;
+        this._currentTotalSelectedTroopCount--;
+      }
+      this.OnCurrentSelectedAmountChange();
+    }
+
+    private void OnAddCount(ManageHideoutTroopItemVM troopItem)
+    {
+      if (troopItem.CurrentAmount < troopItem.MaxAmount && this._currentTotalSelectedTroopCount < this._maxSelectableTroopCount)
+      {
+        troopItem.CurrentAmount++;
+        this._currentTotalSelectedTroopCount++;
+      }
+      this.OnCurrentSelectedAmountChange();
+    }
+
+    private void OnCurrentSelectedAmountChange()
+    {
+      foreach (ManageHideoutTroopItemVM manageHideoutTroopItemVM in this.Troops)
+      {
+        manageHideoutTroopItemVM.IsRosterFull = this._currentTotalSelectedTroopCount >= this._maxSelectableTroopCount;
+      }
+      GameTexts.SetVariable("LEFT", this._currentTotalSelectedTroopCount);
+      GameTexts.SetVariable("RIGHT", this._maxSelectableTroopCount);
+      this.CurrentSelectedAmountText = GameTexts.FindText("str_LEFT_over_RIGHT_in_paranthesis", null).ToString();
+    }
+
+    #region DYN CALLED METHODS
+#pragma warning disable IDE0051 // Remove unused private members
+    /// <summary>
+    /// DO NOT REMOVE THIS IS CALLED DYNAMICALLY
+    /// </summary>
+    private void ExecuteDone()
+    {
+      if (this._currentTotalSelectedTroopCount != this._tournamentKB.TeamSize)
+      {
+        InformationManager.DisplayMessage(new InformationMessage($"Selected team members count must be {this._tournamentKB.TeamSize}."));
+        return;
+      }
+      var troopRoster = new List<CharacterObject>();
+      foreach (ManageHideoutTroopItemVM manageHideoutTroopItemVM in this.Troops)
+      {
+        if (manageHideoutTroopItemVM.CurrentAmount > 0)
+        {
+          for(var i =0; i< manageHideoutTroopItemVM.CurrentAmount; i++)
+            troopRoster.Add(manageHideoutTroopItemVM.Troop.Character);
+        }
+      }
+      this._tournamentKB.SelectedRoster = troopRoster;
+      this.IsEnabled = false;
+      GameMenu.SwitchToMenu("town");
+      this._tournamentKB.TournamentGame.PrepareForTournamentGame(true);
+      Campaign.Current.TournamentManager.OnPlayerJoinTournament(this._tournamentKB.TournamentGame.GetType(), Settlement.CurrentSettlement);
+    }
+
+    /// <summary>
+    /// DO NOT REMOVE THIS IS CALLED DYNAMICALLY
+    /// </summary>
+
+    private void ExecuteCancel()
+
+    {
+      this.IsEnabled = false;
+    }
+
+    /// <summary>
+    /// DO NOT REMOVE THIS IS CALLED DYNAMICALLY
+    /// </summary>
+    private void ExecuteReset()
+    {
+      this.InitializeAvailableSelection();
+      this._maxSelectableTroopCount = _tournamentKB.TeamSize;
+      this.OnCurrentSelectedAmountChange();
+    }
+#pragma warning restore IDE0051 // Remove unused private members
+    #endregion
+
+    #region view properties
+
+    [DataSourceProperty]
+    public bool IsEnabled
+    {
+      get => this._isEnabled;
+
+      set
+      {
+        if (value != this._isEnabled)
+        {
+          this._isEnabled = value;
+          OnPropertyChangedWithValue(value, "IsEnabled");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public MBBindingList<ManageHideoutTroopItemVM> Troops
+    {
+      get => this._troops;
+
+      set
+      {
+        if (value != this._troops)
+        {
+          this._troops = value;
+          OnPropertyChangedWithValue(value, "Troops");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string DoneText
+    {
+      get => this._doneText;
+
+      set
+      {
+        if (value != this._doneText)
+        {
+          this._doneText = value;
+          OnPropertyChangedWithValue(value, "DoneText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string CancelText
+    {
+      get => this._cancelText;
+
+      set
+      {
+        if (value != this._cancelText)
+        {
+          this._cancelText = value;
+          OnPropertyChangedWithValue(value, "CancelText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string TitleText
+    {
+      get => this._titleText;
+
+      set
+      {
+        if (value != this._titleText)
+        {
+          this._titleText = value;
+          OnPropertyChangedWithValue(value, "TitleText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string CurrentSelectedAmountText
+    {
+      get => this._currentSelectedAmountText;
+
+      set
+      {
+        if (value != this._currentSelectedAmountText)
+        {
+          this._currentSelectedAmountText = value;
+          OnPropertyChangedWithValue(value, "CurrentSelectedAmountText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string CurrentSelectedAmountTitle
+    {
+      get => this._currentSelectedAmountTitle;
+
+      set
+      {
+        if (value != this._currentSelectedAmountTitle)
+        {
+          this._currentSelectedAmountTitle = value;
+          OnPropertyChangedWithValue(value, "CurrentSelectedAmountTitle");
+        }
+      }
+    }
+    #endregion
+
+    private TournamentKB _tournamentKB;
+    private int _maxSelectableTroopCount;
+    private int _currentTotalSelectedTroopCount;
+    private bool _isEnabled;
+    private string _doneText;
+    private string _cancelText;
+    private string _titleText;
+    private string _currentSelectedAmountText;
+    private string _currentSelectedAmountTitle;
+    private MBBindingList<ManageHideoutTroopItemVM> _troops;
+  }
+
+}

--- a/src/TeamTournament/MissionGauntletTeamTournamentView.cs
+++ b/src/TeamTournament/MissionGauntletTeamTournamentView.cs
@@ -1,0 +1,131 @@
+﻿using TaleWorlds.CampaignSystem.SandBox.Source.TournamentGames;
+using TaleWorlds.Core;
+using TaleWorlds.Engine;
+using TaleWorlds.Engine.GauntletUI;
+using TaleWorlds.GauntletUI.Data;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.View.Missions;
+using TournamentsEnhanced.TeamTournament.ViewModels;
+
+namespace TournamentsEnhanced.TeamTournament
+{
+  [OverrideView(typeof(TeamTournamentMissionView))]
+  public class MissionGauntletTeamTournamentView : MissionView
+  {
+    private TeamTournamentBehavior _behavior;
+    private Camera _customCamera;
+    private bool _showUi = true;
+    private GauntletMovie _gauntletMovie;
+    private GauntletLayer _gauntletLayer;
+    private TeamTournamentVM _dataSource;
+
+    public MissionGauntletTeamTournamentView()
+    {
+      this.ViewOrderPriorty = 48;
+    }
+
+    public override void OnMissionScreenInitialize()
+    {
+      base.OnMissionScreenInitialize();
+      this._dataSource = new TeamTournamentVM(this.DisableUi, this._behavior);
+      this._gauntletLayer = new GauntletLayer(this.ViewOrderPriorty, "GauntletLayer");
+      this._gauntletMovie = this._gauntletLayer.LoadMovie("Tournament", this._dataSource);
+      base.MissionScreen.CustomCamera = this._customCamera;
+      this._gauntletLayer.InputRestrictions.SetInputRestrictions(true, InputUsageMask.All);
+      base.MissionScreen.AddLayer(this._gauntletLayer);
+    }
+
+    public override void OnMissionScreenFinalize()
+    {
+      this._gauntletLayer.InputRestrictions.ResetInputRestrictions();
+      this._gauntletMovie = null;
+      this._gauntletLayer = null;
+      this._dataSource.OnFinalize();
+      this._dataSource = null;
+      base.OnMissionScreenFinalize();
+    }
+
+    public override void AfterStart()
+    {
+      this._behavior = base.Mission.GetMissionBehaviour<TeamTournamentBehavior>();
+      var gameEntity = base.Mission.Scene.FindEntityWithTag("camera_instance");
+      this._customCamera = Camera.CreateCamera();
+      var vec = default(Vec3);
+      gameEntity.GetCameraParamsFromCameraScript(this._customCamera, ref vec);
+    }
+
+    public override void OnMissionTick(float dt)
+    {
+      if (this._behavior == null)
+      {
+        return;
+      }
+      if (!this._showUi && ((this._behavior.LastMatch != null && this._behavior.CurrentMatch == null) || this._behavior.CurrentMatch.IsReady))
+      {
+        this._dataSource.Refresh();
+        this.ShowUi();
+      }
+      if (!this._showUi && this._dataSource.CurrentMatch.IsValid)
+      {
+        var currentMatch = this._behavior.CurrentMatch;
+        if (currentMatch != null && currentMatch.State == TournamentMatch.MatchState.Started)
+        {
+          this._dataSource.CurrentMatch.RefreshActiveMatch();
+        }
+      }
+      if (this._dataSource.IsOver && this._showUi && !base.DebugInput.IsControlDown() && base.DebugInput.IsHotKeyPressed("ShowHighlightsSummary"))
+      {
+        HighlightsController missionBehaviour = base.Mission.GetMissionBehaviour<HighlightsController>();
+        if (missionBehaviour == null)
+        {
+          return;
+        }
+        missionBehaviour.ShowSummary();
+      }
+    }
+
+    private void DisableUi()
+    {
+      if (!this._showUi)
+      {
+        return;
+      }
+      base.MissionScreen.UpdateFreeCamera(this._customCamera.Frame);
+      base.MissionScreen.CustomCamera = null;
+      this._showUi = false;
+      this._gauntletLayer.InputRestrictions.ResetInputRestrictions();
+    }
+
+    private void ShowUi()
+    {
+      if (this._showUi)
+      {
+        return;
+      }
+      base.MissionScreen.CustomCamera = this._customCamera;
+      this._showUi = true;
+      this._gauntletLayer.InputRestrictions.SetInputRestrictions(true, InputUsageMask.All);
+    }
+
+    public override void OnAgentRemoved(Agent affectedAgent, Agent affectorAgent, AgentState agentState, KillingBlow killingBlow)
+    {
+      base.OnAgentRemoved(affectedAgent, affectorAgent, agentState, killingBlow);
+      this._dataSource.OnAgentRemoved(affectedAgent);
+    }
+
+    public override void OnPhotoModeActivated()
+    {
+      base.OnPhotoModeActivated();
+      this._gauntletLayer._gauntletUIContext.ContextAlpha = 0f;
+    }
+
+    public override void OnPhotoModeDeactivated()
+    {
+      base.OnPhotoModeDeactivated();
+      this._gauntletLayer._gauntletUIContext.ContextAlpha = 1f;
+    }
+  }
+
+  public class TeamTournamentMissionView : MissionView { }
+}

--- a/src/TeamTournament/Patches/MissionStarterOpenTournamentFightMissionPatch.cs
+++ b/src/TeamTournament/Patches/MissionStarterOpenTournamentFightMissionPatch.cs
@@ -1,0 +1,41 @@
+﻿using HarmonyLib;
+using SandBox;
+using SandBox.Source.Missions;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Source.Missions;
+
+namespace TournamentsEnhanced.TeamTournament.Patches
+{
+  [HarmonyPatch(typeof(MissionStarter), "OpenTournamentFightMission")]
+  class MissionStarterOpenTournamentFightMissionPatch
+  {
+    static bool Prefix(ref Mission __result, string scene, TournamentGame tournamentGame, Settlement settlement, CultureObject culture, bool isPlayerParticipating)
+    {
+      if (TournamentKB.Current != null && TournamentKB.Current.IsTeamTournament)
+      {
+        __result = MissionState.OpenNew("TournamentFight", SandBoxMissions.CreateSandBoxMissionInitializerRecord(scene, "", false), delegate (Mission missionController)
+        {
+          var tournamentMissionController = new TeamTournamentMissionController(culture);
+          return new MissionBehaviour[]
+          {
+          new CampaignMissionComponent(),
+          tournamentMissionController,
+          new TeamTournamentBehavior(tournamentGame, settlement, tournamentMissionController, isPlayerParticipating), // this is patched!
+          new AgentVictoryLogic(),
+          new MissionAgentPanicHandler(),
+          new AgentBattleAILogic(),
+          new ArenaAgentStateDeciderLogic(),
+          new MissionHardBorderPlacer(),
+          new MissionBoundaryPlacer(),
+          new MissionOptionsComponent(),
+          new HighlightsController(),
+          new SandboxHighlightsController()
+          };
+        }, true, true);
+        return false;
+      }
+      return true;
+    }
+  }
+}

--- a/src/TeamTournament/Patches/TournamentMissionViewsOpenTournamentFightMissionPatch.cs
+++ b/src/TeamTournament/Patches/TournamentMissionViewsOpenTournamentFightMissionPatch.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using SandBox.View;
+using SandBox.View.Missions;
+using SandBox.View.Missions.Tournaments;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.LegacyGUI.Missions;
+using TaleWorlds.MountAndBlade.View.Missions;
+
+namespace TournamentsEnhanced.TeamTournament.Patches
+{
+
+  [HarmonyPatch(typeof(TournamentMissionViews), "OpenTournamentFightMission")]
+  class TournamentMissionViewsOpenTournamentFightMissionPatch
+  {
+    static bool Prefix(ref MissionView[] __result, Mission mission)
+    {
+      if (TournamentKB.Current != null && TournamentKB.Current.IsTeamTournament)
+      {
+        __result = new List<MissionView>
+        {
+          new CampaignMissionView(),
+          new ConversationCameraView(),
+          ViewCreator.CreateMissionSingleplayerEscapeMenu(),
+          ViewCreator.CreateOptionsUIHandler(),
+          ViewCreatorManager.CreateMissionView<MissionGauntletTeamTournamentView>(false, null, Array.Empty<object>()), // this is patched!
+          new MissionAudienceHandler(0.4f + MBRandom.RandomFloat * 0.6f),
+          ViewCreator.CreateMissionAgentStatusUIHandler(mission),
+          ViewCreator.CreateMissionMainAgentEquipmentController(mission),
+          ViewCreator.CreateMissionMainAgentCheerControllerView(mission),
+          ViewCreator.CreateMissionAgentLockVisualizerView(mission),
+          new MusicTournamentMissionView(),
+          new MissionSingleplayerUIHandler(),
+          ViewCreator.CreateSingleplayerMissionKillNotificationUIHandler(),
+          new MusicMissionView(new MusicBaseComponent[]
+          {
+            new MusicMissionTournamentComponent()
+          }),
+          ViewCreator.CreateMissionAgentLabelUIHandler(mission),
+          new MissionItemContourControllerView(),
+          ViewCreator.CreatePhotoModeView()
+        }.ToArray();
+        return false;
+      }
+      return true;
+    }
+  }
+}

--- a/src/TeamTournament/TeamTournamentBehavior.cs
+++ b/src/TeamTournament/TeamTournamentBehavior.cs
@@ -1,0 +1,459 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Helpers;
+using SandBox.TournamentMissions.Missions;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.SandBox.Source.TournamentGames;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using TaleWorlds.MountAndBlade;
+
+namespace TournamentsEnhanced.TeamTournament
+{
+  public class TeamTournamentBehavior : MissionLogic, ICameraModeLogic
+  {
+    public TournamentGame TournamentGame { get; private set; }
+    public int PlayerTeamLostAtRound { get => _playerLostAtRound; }
+    public bool IsPlayerEliminated { get; private set; }
+    public int CurrentRoundIndex { get; private set; }
+    public TeamTournamentMatch LastMatch { get; private set; }
+    public TeamTournamentRound[] Rounds { get; private set; }
+    public SpectatorCameraTypes GetMissionCameraLockMode(bool lockedToMainPlayer)
+      => !this.IsPlayerParticipating ? SpectatorCameraTypes.LockToAnyAgent : SpectatorCameraTypes.Invalid;
+    public TeamTournamentRound CurrentRound => this.Rounds[this.CurrentRoundIndex];
+    public TeamTournamentRound NextRound => this.CurrentRoundIndex < this.Rounds.Length - 1 ? this.Rounds[this.CurrentRoundIndex + 1] : null;
+    public TeamTournamentMatch CurrentMatch => this.CurrentRound != null ? this.CurrentRound.CurrentMatch : null;
+    public TeamTournamentMember Winner { get; private set; }
+    public bool IsPlayerParticipating { get; private set; }
+    public Settlement Settlement { get; private set; }
+    public float BetOdd { get; private set; }
+    public int MaximumBetInstance => Math.Min(150, this.PlayerDenars);
+    public int BettedDenars { get; private set; }
+    public int OverallExpectedDenars { get; private set; }
+    public int PlayerDenars => Hero.MainHero.Gold;
+    private TournamentKB CurrentTKB { get; set; }
+    private TeamTournamentMissionController MissionBehavior { get; set; }
+
+    public TeamTournamentBehavior(TournamentGame tournamentGame, Settlement settlement, ITournamentGameBehavior gameBehavior, bool isPlayerParticipating)
+    {
+      this.Settlement = settlement;
+      this.TournamentGame = tournamentGame;
+      this.MissionBehavior = gameBehavior as TeamTournamentMissionController;
+      this.CurrentTKB = TournamentKB.Current;
+      this.Rounds = new TeamTournamentRound[CurrentTKB.Rounds];
+      this.CreateTeams();
+      this.CurrentRoundIndex = -1;
+      this.LastMatch = null;
+      this.Winner = null;
+      this.IsPlayerParticipating = isPlayerParticipating;
+    }
+
+    private void CreateTeams()
+    {
+      // first we take in our selected team
+      var mainParticipants = new List<TeamTournamentMember>(CurrentTKB.SelectedRoster.Select(x => new TeamTournamentMember(x)));
+      _teams = new List<TeamTournamentTeam>() {
+          new TeamTournamentTeam(mainParticipants, Hero.MainHero.ClanBanner, Hero.MainHero.ClanBanner.GetPrimaryColor())
+      };
+
+      // now create rest
+      var createdTeams = CreateTournamentTeams();
+
+      // if we managed to get all, merge with our team and set
+      _teams.AddRange(createdTeams);
+    }
+
+    private List<TeamTournamentTeam> CreateTournamentTeams()
+    {
+      var teamComposition = new List<TournamentParticipant>();
+
+      // now check out if we can form teams locally from other heroes
+      var heroesInSettlement = this.Settlement
+        .GetHeroesInSettlement()
+        .Where(x => !CurrentTKB.SelectedRoster.Contains(x)
+            && !x.HeroObject.Noncombatant
+            && x.Age >= Campaign.Current.Models.AgeModel.HeroComesOfAge
+            && (x.HeroObject.IsWanderer || x.HeroObject.IsNoble));
+
+      var createdTeams = new List<TeamTournamentTeam>();
+      var addedParticipants = new List<CharacterObject>();
+
+      // TODO: appy logic from TournamentParticipantPatch
+
+      // first try to get teams of every local party, "they arrived just for this event"
+      foreach (var partyLeader in heroesInSettlement.Where(x => x.HeroObject.IsPartyLeader))
+      {
+        var strongestPartyTeam = MobilePartyHelper
+          .GetStrongestAndPriorTroops(partyLeader.HeroObject.PartyBelongedTo, CurrentTKB.TeamSize, false)
+          .Select(x => new TeamTournamentMember(x.Troop));
+
+        // if this party can't at least have a team full team, drop them
+        if (strongestPartyTeam.Count() == CurrentTKB.TeamSize)
+        {
+          createdTeams.Add(new TeamTournamentTeam(strongestPartyTeam.ToList()));
+          addedParticipants.AddRange(strongestPartyTeam.Select(x => x.Character));
+        }
+
+        if (createdTeams.Count >= CurrentTKB.TeamsCount - 1) // remember we already have one team
+          return createdTeams;
+      }
+
+      var currentTeam = new List<TeamTournamentMember>();
+
+      // if we are still not done, create teams with local heroes
+      var possibleHeroes = heroesInSettlement.Where(x => !x.HeroObject.IsPartyLeader && !addedParticipants.Contains(x)).ToList();
+      foreach (var localHero in possibleHeroes)
+      {
+        currentTeam.Add(new TeamTournamentMember(localHero));
+
+        if (currentTeam.Count() >= CurrentTKB.TeamSize)
+        {
+          var team1 = new TeamTournamentTeam(currentTeam);
+          createdTeams.Add(team1);
+          currentTeam = new List<TeamTournamentMember>();
+        }
+
+        if (possibleHeroes.Count() - currentTeam.Count() <= 0 && currentTeam.Count() > 0) // fill up hero team if no more heroes left 
+        {
+          var simpletonList = GetSimpletons(Settlement.Culture).Shuffle().Take(CurrentTKB.TeamSize - currentTeam.Count()).Select(x => new TeamTournamentMember(x)).ToList();
+          currentTeam.AddRange(simpletonList);
+          createdTeams.Add(new TeamTournamentTeam(currentTeam));
+          currentTeam = new List<TeamTournamentMember>();
+        }
+
+        if (createdTeams.Count >= CurrentTKB.TeamsCount - 1) // remember we already have one team
+          return createdTeams;
+      }
+
+      // well still not done, just add troops to fill it
+      var possibleSimpletons = GetSimpletons(Settlement.Culture).ToList();
+      if (possibleSimpletons.Count > 0)
+      {
+        do
+        {
+          var teamToAdd = new List<CharacterObject>();
+          for (var i = 0; i < CurrentTKB.TeamSize; i++)
+          {
+            teamToAdd.Add(possibleSimpletons.GetRandomElement());
+          }
+          createdTeams.Add(new TeamTournamentTeam(teamToAdd.Select(x => new TeamTournamentMember(x)).ToList()));
+        }
+        while (createdTeams.Count < CurrentTKB.TeamsCount - 1);
+
+        if (createdTeams.Count >= CurrentTKB.TeamsCount - 1) // remember we already have one team
+          return createdTeams;
+      }
+
+      // if not done here, something was really bad fill up with ALL
+      possibleSimpletons = GetSimpletons().ToList();
+      if (possibleSimpletons.Count > 0)
+      {
+        do
+        {
+          var teamToAdd = new List<CharacterObject>();
+          for (var i = 0; i < CurrentTKB.TeamSize; i++)
+          {
+            teamToAdd.Add(possibleSimpletons.GetRandomElement());
+          }
+          createdTeams.Add(new TeamTournamentTeam(teamToAdd.Select(x => new TeamTournamentMember(x)).ToList()));
+        }
+        while (createdTeams.Count < CurrentTKB.TeamsCount - 1);
+        return createdTeams;
+      }
+
+      return null;
+    }
+
+    private List<CharacterObject> GetSimpletons(CultureObject culture = null, CharacterObject baseChar = null)
+    {
+      if (baseChar == null)
+        baseChar = CharacterObject.FindFirst(x => x.IsBasicTroop && x.UpgradeTargets != null && (culture != null ? x.Culture == culture : true));
+
+      var simpletons = new List<CharacterObject>() { baseChar };
+
+      if (baseChar.UpgradeTargets != null && baseChar.UpgradeTargets.Length > 0)
+      {
+        for (var i = 0; i < baseChar.UpgradeTargets.Length; i++)
+          simpletons.AddRange(GetSimpletons(culture, baseChar.UpgradeTargets[i]));
+      }
+
+      return simpletons;
+    }
+
+    public override void AfterStart()
+    {
+      this.CurrentRoundIndex = 0;
+      this.CreateTorunamentTree();
+      this.CalculateBet();
+      Utilities.SetDifficulty();
+    }
+
+    public override void OnMissionTick(float dt)
+    {
+      if (this.CurrentMatch != null && this.CurrentMatch.State == TournamentMatch.MatchState.Started && this.MissionBehavior.IsMatchEnded())
+        this.EndCurrentMatch();
+    }
+
+    public void StartMatch()
+    {
+      if (this.CurrentMatch.IsPlayerParticipating)
+      {
+        Campaign.Current.TournamentManager.OnPlayerJoinMatch(this.TournamentGame.GetType());
+      }
+      this.CurrentMatch.Start();
+      base.Mission.SetMissionMode(MissionMode.Tournament, true);
+      this.MissionBehavior.StartMatch(this.CurrentMatch, this.NextRound == null);
+      CampaignEventDispatcher.Instance.OnPlayerStartedTournamentMatch(this.Settlement.Town);
+    }
+
+    public void SkipMatch()
+    {
+      if (this.CurrentMatch.IsReady)
+        this.CurrentMatch.Start();
+
+      this.MissionBehavior.SkipMatch(this.CurrentMatch);
+      this.EndCurrentMatch();
+    }
+
+    private void EndCurrentMatch()
+    {
+      this.LastMatch = this.CurrentMatch;
+      this.CurrentRound.EndMatch();
+      this.MissionBehavior.OnMatchEnded();
+
+      // add winners to next round
+      if (this.NextRound != null)
+      {
+        // fill in round
+        this.LastMatch.Winners.ToList().ForEach(x => NextRound.AddTeam(x));
+        this.MatchEnd?.Invoke(this.LastMatch);
+      }
+
+      // fire off events if player was disqualified 
+      if (this.LastMatch.IsPlayerParticipating)
+      {
+        if (!this.LastMatch.IsPlayerTeamWinner)
+          this.OnPlayerTeamEliminated();
+        else
+          this.OnPlayerTeamWinMatch();
+      }
+
+      if (this.CurrentRound.CurrentMatch == null) // done with this round
+      {
+        // check if done with Tournament or not
+        if (this.CurrentRoundIndex < this.Rounds.Length - 1)
+        {
+          // not done yet, go to next round
+          this.CurrentRoundIndex++;
+          this.CalculateBet();
+        }
+        else
+        {
+          // done with Tournament
+          this.CalculateBet();
+          InformationManager.AddQuickInformation(new TextObject("{=tWzLqegB}Tournament is over.", null), 0, null, "");
+          this.Winner = this.LastMatch.Winners.First().GetTeamLeader();
+          if (this.Winner.Character.IsHero)
+          {
+            if (this.Winner.Character == CharacterObject.PlayerCharacter)
+              this.OnPlayerWinTournament();
+
+            Campaign.Current.TournamentManager.AddLeaderboardEntry(this.Winner.Character.HeroObject);
+          }
+          Utilities.UnsetDifficulty();
+          CampaignEventDispatcher.Instance.OnTournamentFinished(this.Winner.Character, this.Settlement.Town);
+          this.TournamentEnd?.Invoke();
+        }
+      }
+    }
+
+    private void OnPlayerTeamEliminated()
+    {
+      this._playerLostAtRound = this.CurrentRoundIndex + 1;
+      this.IsPlayerEliminated = true;
+      this.BetOdd = 0f;
+      if (this.BettedDenars > 0)
+      {
+        GiveGoldAction.ApplyForCharacterToSettlement(null, Settlement.CurrentSettlement, this.BettedDenars, false);
+      }
+      this.OverallExpectedDenars = 0;
+      CampaignEventDispatcher.Instance.OnPlayerEliminatedFromTournament(this.CurrentRoundIndex, this.Settlement.Town);
+    }
+
+    private void OnPlayerTeamWinMatch() => Campaign.Current.TournamentManager.OnPlayerWinMatch(this.TournamentGame.GetType());
+
+    private void OnPlayerWinTournament()
+    {
+      if (Campaign.Current.GameMode != CampaignGameMode.Campaign)
+        return;
+
+      GainRenownAction.Apply(Hero.MainHero, this.TournamentGame.TournamentWinRenown, false);
+
+      if (Hero.MainHero.MapFaction.IsKingdomFaction && Hero.MainHero.MapFaction.Leader != Hero.MainHero)
+        GainKingdomInfluenceAction.ApplyForDefault(Hero.MainHero, 1f);
+
+      Hero.MainHero.PartyBelongedTo.ItemRoster.AddToCounts(this.TournamentGame.Prize, 1);
+
+      if (this.OverallExpectedDenars > 0)
+        GiveGoldAction.ApplyBetweenCharacters(null, Hero.MainHero, this.OverallExpectedDenars, false);
+
+      Campaign.Current.TournamentManager.OnPlayerWinTournament(this.TournamentGame.GetType());
+    }
+
+    private void CreateTorunamentTree()
+    {
+      var T = CurrentTKB.TeamsCount;          // Teams count
+      var R = CurrentTKB.Rounds;              // Rounds count 
+      var M = CurrentTKB.FirstRoundMatches;   // Matches count
+      var TPM = T / M;                        // Teams per match
+      var W = TPM / 2;                        // Winners per match
+
+      if (Math.Log(T, 2) > 4) // current interface allows 4 rounds max
+        W = 1;
+
+      for (int r = 0; r < R; r++)
+      {
+        Rounds[r] = new TeamTournamentRound(T, M, W);
+
+        if (r < R)
+        {
+          T = W * M;
+          TPM = Math.Max(Math.Min(MBRandom.Random.Next(0, 2) * 2 + 2, T / 2), 2);
+          M = T / TPM;
+          W = TPM / 2;
+        }
+      }
+
+      // fill in first round
+      this._teams.ForEach(x => Rounds[0].AddTeam(x));
+    }
+
+    public override InquiryData OnEndMissionRequest(out bool canPlayerLeave)
+    {
+      canPlayerLeave = false;
+      return null;
+    }
+
+    public void PlaceABet(int bet)
+    {
+      this.BettedDenars += bet;
+      this.OverallExpectedDenars += this.GetExpectedDenarsForBet(bet);
+      GiveGoldAction.ApplyBetweenCharacters(Hero.MainHero, null, bet, true);
+    }
+
+    public int GetExpectedDenarsForBet(int bet) => (int)(this.BetOdd * bet);
+
+    public int GetMaximumBet()
+    {
+      if (Hero.MainHero.GetPerkValue(DefaultPerks.Roguery.DeepPockets))
+        return 150 * (int)DefaultPerks.Roguery.DeepPockets.PrimaryBonus;
+      return 150;
+    }
+
+    // TODO: this needs "rework"
+    private void CalculateBet()
+    {
+      if (this.IsPlayerParticipating)
+      {
+        if (this.CurrentRound.CurrentMatch == null)
+        {
+          this.BetOdd = 0f;
+          return;
+        }
+
+        if (this.IsPlayerEliminated || !this.IsPlayerParticipating)
+        {
+          this.OverallExpectedDenars = 0;
+          this.BetOdd = 0f;
+          return;
+        }
+
+        List<KeyValuePair<Hero, int>> leaderboard = Campaign.Current.TournamentManager.GetLeaderboard();
+        int num = 0;
+        int num2 = 0;
+        for (int i = 0; i < leaderboard.Count; i++)
+        {
+          if (leaderboard[i].Key == Hero.MainHero)
+          {
+            num = leaderboard[i].Value;
+          }
+          if (leaderboard[i].Value > num2)
+          {
+            num2 = leaderboard[i].Value;
+          }
+        }
+
+        float baseOdd = 30f + (float)Hero.MainHero.Level + (float)Math.Max(0, num * 12 - num2 * 2);
+        float num4 = 0f;
+        float num5 = 0f;
+        float num6 = 0f;
+
+        foreach (var tournamentMatch in this.CurrentRound.Matches)
+        {
+          foreach (var tournamentTeam in tournamentMatch.Teams)
+          {
+            float num7 = 0f;
+            foreach (var tournamentParticipant in tournamentTeam.Members)
+            {
+              if (tournamentParticipant.Character != CharacterObject.PlayerCharacter)
+              {
+                int num8 = 0;
+                if (tournamentParticipant.Character.IsHero)
+                {
+                  for (int k = 0; k < leaderboard.Count; k++)
+                  {
+                    if (leaderboard[k].Key == tournamentParticipant.Character.HeroObject)
+                    {
+                      num8 = leaderboard[k].Value;
+                    }
+                  }
+                }
+                num7 += (float)(tournamentParticipant.Character.Level + Math.Max(0, num8 * 8 - num2 * 2));
+              }
+            }
+            if (tournamentTeam.IsPlayerTeam)
+            {
+              num5 = num7;
+              foreach (var tournamentTeam2 in tournamentMatch.Teams)
+              {
+                if (tournamentTeam != tournamentTeam2)
+                {
+                  foreach (var tournamentParticipant2 in tournamentTeam2.Members)
+                  {
+                    int num9 = 0;
+                    if (tournamentParticipant2.Character.IsHero)
+                    {
+                      for (int l = 0; l < leaderboard.Count; l++)
+                      {
+                        if (leaderboard[l].Key == tournamentParticipant2.Character.HeroObject)
+                        {
+                          num9 = leaderboard[l].Value;
+                        }
+                      }
+                    }
+                    num6 += (float)(tournamentParticipant2.Character.Level + Math.Max(0, num9 * 8 - num2 * 2));
+                  }
+                }
+              }
+            }
+            num4 += num7;
+          }
+        }
+        float num10 = (num5 + baseOdd) / (num6 + num5 + baseOdd);
+        float num11 = baseOdd / (num5 + baseOdd + 0.5f * (num4 - (num5 + num6)));
+        float num13 = MathF.Clamp((float)Math.Pow((double)(1f / num10 * num11), 0.75), 1.1f, 4f);
+        this.BetOdd = (int)(num13 * 10f) / 10f;
+      }
+    }
+
+    public event Action TournamentEnd;
+    public event Action<TeamTournamentMatch> MatchEnd;
+    public const float EndMatchTimerDuration = 6f;
+    private List<TeamTournamentTeam> _teams;
+    private int _playerLostAtRound;
+    public const float MaximumOdd = 4f;
+  }
+}

--- a/src/TeamTournament/TeamTournamentBehavior.cs
+++ b/src/TeamTournament/TeamTournamentBehavior.cs
@@ -370,82 +370,8 @@ namespace TournamentsEnhanced.TeamTournament
           this.BetOdd = 0f;
           return;
         }
-
-        List<KeyValuePair<Hero, int>> leaderboard = Campaign.Current.TournamentManager.GetLeaderboard();
-        int num = 0;
-        int num2 = 0;
-        for (int i = 0; i < leaderboard.Count; i++)
-        {
-          if (leaderboard[i].Key == Hero.MainHero)
-          {
-            num = leaderboard[i].Value;
-          }
-          if (leaderboard[i].Value > num2)
-          {
-            num2 = leaderboard[i].Value;
-          }
-        }
-
-        float baseOdd = 30f + (float)Hero.MainHero.Level + (float)Math.Max(0, num * 12 - num2 * 2);
-        float num4 = 0f;
-        float num5 = 0f;
-        float num6 = 0f;
-
-        foreach (var tournamentMatch in this.CurrentRound.Matches)
-        {
-          foreach (var tournamentTeam in tournamentMatch.Teams)
-          {
-            float num7 = 0f;
-            foreach (var tournamentParticipant in tournamentTeam.Members)
-            {
-              if (tournamentParticipant.Character != CharacterObject.PlayerCharacter)
-              {
-                int num8 = 0;
-                if (tournamentParticipant.Character.IsHero)
-                {
-                  for (int k = 0; k < leaderboard.Count; k++)
-                  {
-                    if (leaderboard[k].Key == tournamentParticipant.Character.HeroObject)
-                    {
-                      num8 = leaderboard[k].Value;
-                    }
-                  }
-                }
-                num7 += (float)(tournamentParticipant.Character.Level + Math.Max(0, num8 * 8 - num2 * 2));
-              }
-            }
-            if (tournamentTeam.IsPlayerTeam)
-            {
-              num5 = num7;
-              foreach (var tournamentTeam2 in tournamentMatch.Teams)
-              {
-                if (tournamentTeam != tournamentTeam2)
-                {
-                  foreach (var tournamentParticipant2 in tournamentTeam2.Members)
-                  {
-                    int num9 = 0;
-                    if (tournamentParticipant2.Character.IsHero)
-                    {
-                      for (int l = 0; l < leaderboard.Count; l++)
-                      {
-                        if (leaderboard[l].Key == tournamentParticipant2.Character.HeroObject)
-                        {
-                          num9 = leaderboard[l].Value;
-                        }
-                      }
-                    }
-                    num6 += (float)(tournamentParticipant2.Character.Level + Math.Max(0, num9 * 8 - num2 * 2));
-                  }
-                }
-              }
-            }
-            num4 += num7;
-          }
-        }
-        float num10 = (num5 + baseOdd) / (num6 + num5 + baseOdd);
-        float num11 = baseOdd / (num5 + baseOdd + 0.5f * (num4 - (num5 + num6)));
-        float num13 = MathF.Clamp((float)Math.Pow((double)(1f / num10 * num11), 0.75), 1.1f, 4f);
-        this.BetOdd = (int)(num13 * 10f) / 10f;
+        // TODO: make a better bet odd calculation
+        this.BetOdd = MBRandom.Random.Next(3, 5);
       }
     }
 

--- a/src/TeamTournament/TeamTournamentHelpers.cs
+++ b/src/TeamTournament/TeamTournamentHelpers.cs
@@ -21,5 +21,33 @@ namespace TournamentsEnhanced.TeamTournament
             && !x.IsHidden)
         .Select(sel => sel.Character);
     }
+
+    public static IEnumerable<Hero> AllLivingRelatedHeroes(this Hero inHero)
+    {
+      if (inHero.Father != null && !inHero.Father.IsDead)
+        yield return inHero.Father;
+
+      if (inHero.Mother != null && !inHero.Mother.IsDead)
+        yield return inHero.Mother;
+
+      if (inHero.Spouse != null && !inHero.Spouse.IsDead)
+        yield return inHero.Spouse;
+
+      foreach (Hero hero in inHero.Children)
+      {
+        if (!hero.IsDead)
+          yield return hero;
+      }
+      foreach (Hero hero2 in inHero.Siblings)
+      {
+        if (!hero2.IsDead)
+          yield return hero2;
+      }
+      foreach (Hero hero3 in inHero.ExSpouses)
+      {
+        if (!hero3.IsDead)
+          yield return hero3;
+      }
+    }
   }
 }

--- a/src/TeamTournament/TeamTournamentHelpers.cs
+++ b/src/TeamTournament/TeamTournamentHelpers.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+
+namespace TournamentsEnhanced.TeamTournament
+{
+  public static class TeamTournamentHelpers
+  {
+    /// <summary>
+    /// Returns all found characters which are heroes inside a settlement.
+    /// </summary>
+    /// <param name="settlement">Settlement to find the heroes in</param>
+    /// <returns>List of all found hero characters inside the settlement</returns>
+    public static IEnumerable<CharacterObject> GetHeroesInSettlement(this Settlement settlement)
+    {
+      return settlement.LocationComplex
+        .GetListOfCharacters()
+        .Where(x =>
+            x != null
+            && x.Character.IsHero
+            && !x.IsHidden)
+        .Select(sel => sel.Character);
+    }
+  }
+}

--- a/src/TeamTournament/TeamTournamentMatch.cs
+++ b/src/TeamTournament/TeamTournamentMatch.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.Core;
+using static TaleWorlds.CampaignSystem.SandBox.Source.TournamentGames.TournamentMatch;
+
+namespace TournamentsEnhanced.TeamTournament
+{
+  public class TeamTournamentMatch
+  {
+    public IEnumerable<TeamTournamentTeam> Teams { get => _teams; }
+    public MatchState State { get; private set; }
+    public bool IsReady => this.State == MatchState.Ready;
+    public bool IsFinished => this.State == MatchState.Finished;
+
+    public static int[] TeamColors = new int[] // TODO: maybe make a setting out of this
+    {
+      119,
+      118,
+      120,
+      121
+    };
+
+    public IEnumerable<TeamTournamentTeam> Winners => this.GetWinners();
+
+    public TeamTournamentMatch(int teamCount, int winnerTeamsPerMatch)
+    {
+      this._winnerTeamsPerMatch = winnerTeamsPerMatch;
+      _teams = new List<TeamTournamentTeam>(teamCount);
+      this.State = MatchState.Ready;
+    }
+
+    public void AddTeam(TeamTournamentTeam team)
+    {
+      if (!team.IsPlayerTeam)
+      {
+        team.TeamColor = BannerManager.GetColor(TeamColors[_teams.Count]);
+        team.TeamBanner = Banner.CreateOneColoredEmptyBanner(_teams.Count);
+      }
+      _teams.Add(team);
+    }
+
+    public void End()
+    {
+      this.State = MatchState.Finished;
+      this._winners = this.GetWinners();
+    }
+
+    public void Start()
+    {
+      if (this.State != MatchState.Started)
+      {
+        this.State = MatchState.Started;
+        _teams.ForEach(t => t.ResetScore());
+      }
+    }
+    public IEnumerable<TeamTournamentMember> MatchMembers => this.Teams.SelectMany(x => x.Members);
+    public bool IsPlayerParticipating => this.Teams.Any(x => x.IsPlayerTeam);
+    public bool IsPlayerTeamWinner => GetWinners().Any(x => x.IsPlayerTeam);
+
+    public bool IsFullMatch => _teams.Count == _teams.Capacity;
+
+    private List<TeamTournamentTeam> GetWinners()
+    {
+      if (this.State != MatchState.Finished || _winners == null)
+        _winners = this.Teams.OrderByDescending(x => x.Score).Take(this._winnerTeamsPerMatch).ToList();
+
+      return _winners;
+    }
+
+    private readonly int _winnerTeamsPerMatch;
+    private List<TeamTournamentTeam> _winners;
+    private List<TeamTournamentTeam> _teams;
+  }
+}
+

--- a/src/TeamTournament/TeamTournamentMember.cs
+++ b/src/TeamTournament/TeamTournamentMember.cs
@@ -1,0 +1,35 @@
+﻿using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+
+namespace TournamentsEnhanced.TeamTournament
+{
+  public class TeamTournamentMember
+  {
+    public int Score { get; private set; }
+    public CharacterObject Character { get; private set; }
+    public UniqueTroopDescriptor Descriptor { get; private set; }
+    public TeamTournamentTeam Team { get => _team; private set { _team = value; } }
+    public Equipment MatchEquipment { get; set; }
+    public bool IsPlayer => Character != null && Character.IsPlayerCharacter;
+
+    public TeamTournamentMember(CharacterObject character)
+    {
+      this.Character = character;
+      this.Descriptor = new UniqueTroopDescriptor(Game.Current.NextUniqueTroopSeed);
+    }
+
+    public int AddScore(int score)
+    {
+      this.Score += score;
+      return this.Score;
+    }
+
+    public void SetTeam(TeamTournamentTeam team) => this.Team = team;
+
+    private TeamTournamentTeam _team;
+
+    public void ResetScore() => this.Score = 0;
+
+    public bool IsCharWithDescriptor(int uniqueTroopSeed) => this.Descriptor.CompareTo(uniqueTroopSeed) == 0;
+  }
+}

--- a/src/TeamTournament/TeamTournamentMissionController.cs
+++ b/src/TeamTournament/TeamTournamentMissionController.cs
@@ -1,0 +1,474 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SandBox.Source.Missions.AgentControllers;
+using SandBox.TournamentMissions.Missions;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CharacterDevelopment.Managers;
+using TaleWorlds.CampaignSystem.SandBox.Source.TournamentGames;
+using TaleWorlds.Core;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.ObjectSystem;
+
+namespace TournamentsEnhanced.TeamTournament
+{
+  public class TeamTournamentMissionController : MissionLogic, ITournamentGameBehavior
+  {
+    private const float XpShareForDamage = 0.5f;
+
+    public TeamTournamentMissionController(CultureObject culture)
+    {
+      this._culture = culture;
+    }
+
+    public override void AfterStart()
+    {
+      TournamentBehavior.DeleteTournamentSetsExcept(base.Mission.Scene.FindEntityWithTag("tournament_fight"));
+      this._spawnPoints = new List<GameEntity>();
+
+      for (int i = 0; i < 4; i++)
+      {
+        var gameEntity = base.Mission.Scene.FindEntityWithTag("sp_arena_" + (i + 1));
+        if (gameEntity != null)
+          this._spawnPoints.Add(gameEntity);
+      }
+
+      if (this._spawnPoints.Count < 4)
+        this._spawnPoints = base.Mission.Scene.FindEntitiesWithTag("sp_arena").ToList<GameEntity>();
+    }
+
+    public void PrepareForMatch() // also called from skip SkipMatch
+    {
+      var numMembers = Math.Max(Math.Min(this._match.Teams.Max(x => x.Members.Count()), 4), 2);
+      var teamWeaponEquipmentList = this.GetTeamWeaponEquipmentList(numMembers);
+
+      foreach (var team in _match.Teams)
+      {
+        int num = 0;
+        foreach (var tournamentMember in team.Members)
+        {
+          tournamentMember.MatchEquipment = teamWeaponEquipmentList[num].Clone(false);
+          this.AddRandomClothes(this._culture, tournamentMember);
+          num = num++ % numMembers;
+        }
+      }
+    }
+
+    public void StartMatch(TeamTournamentMatch match, bool isLastRound)
+    {
+      this._match = match;
+      this._isLastRound = isLastRound;
+      this.PrepareForMatch();
+      base.Mission.SetMissionMode(MissionMode.Battle, true);
+      var tmpList = new List<Team>();
+      int count = this._spawnPoints.Count;
+      foreach (var tournamentTeam in this._match.Teams)
+      {
+        var side = tournamentTeam.IsPlayerTeam ? BattleSideEnum.Defender : BattleSideEnum.Attacker;
+        var team = base.Mission.Teams.Add(side, tournamentTeam.TeamColor, uint.MaxValue, tournamentTeam.TeamBanner, true, false, true);
+        var spawnPoint = this._spawnPoints[tmpList.Count % count];
+
+        foreach (var tournamentMember in tournamentTeam.Members)
+          this.SpawnTournamentMember(spawnPoint, tournamentMember, team);
+
+        tmpList.ForEach(x => x.SetIsEnemyOf(team, true));
+        tmpList.Add(team);
+      }
+      this._aliveMembers = new List<TeamTournamentMember>(this._match.MatchMembers);
+      this._aliveTeams = new List<TeamTournamentTeam>(this._match.Teams);
+    }
+
+    private void SpawnTournamentMember(GameEntity spawnPoint, TeamTournamentMember member, Team team)
+    {
+      MatrixFrame globalFrame = spawnPoint.GetGlobalFrame();
+      globalFrame.rotation.OrthonormalizeAccordingToForwardAndKeepUpAsZAxis();
+      this.SpawnAgentWithRandomItems(member, team, globalFrame);
+    }
+
+    private List<Equipment> GetTeamWeaponEquipmentList(int teamSize)
+    {
+      var retList = new List<Equipment>();
+      CultureObject culture = PlayerEncounter.EncounterSettlement.Culture;
+      var equiptmentSet = teamSize == 4 ? culture.TournamentTeamTemplatesForFourParticipant : (teamSize == 2 ? culture.TournamentTeamTemplatesForTwoParticipant : culture.TournamentTeamTemplatesForOneParticipant);
+      CharacterObject characterObject;
+
+      if (equiptmentSet.Count > 0)
+        characterObject = equiptmentSet[MBRandom.RandomInt(equiptmentSet.Count)];
+      else
+        characterObject = teamSize == 4 ? this._defaultWeaponTemplatesIdTeamSizeFour : (teamSize == 2 ? this._defaultWeaponTemplatesIdTeamSizeTwo : this._defaultWeaponTemplatesIdTeamSizeOne);
+
+      foreach (var sourceEquipment in characterObject.BattleEquipments)
+      {
+        var equipment = new Equipment();
+        equipment.FillFrom(sourceEquipment, true);
+        retList.Add(equipment);
+      }
+      return retList;
+    }
+
+    public void SkipMatch(TeamTournamentMatch match)
+    {
+      this._match = match;
+      this.PrepareForMatch();
+      this.Simulate();
+    }
+
+    public bool IsMatchEnded()
+    {
+      if (this._isSimulated || this._match == null)
+        return true;
+
+      if ((this._endTimer != null && this._endTimer.ElapsedTime > 6f) || this._forceEndMatch)
+      {
+        this._forceEndMatch = false;
+        this._endTimer = null;
+        return true;
+      }
+
+      if (this._cheerTimer != null && this._cheerTimer.ElapsedTime > 1f)
+      {
+        this.OnMatchResultsReady();
+        this._cheerTimer = null;
+
+        foreach (Agent agent in base.Mission.Agents)
+        {
+          if (agent.IsAIControlled)
+            Mission.GetMissionBehaviour<AgentVictoryLogic>().SetTimersOfVictoryReactions(agent, 1f, 3f);
+        }
+
+        return false;
+      }
+
+      if (this._endTimer == null && !this.CheckIfIsThereAnyEnemies())
+      {
+        this._endTimer = new BasicTimer(MBCommon.TimeType.Mission);
+        this._cheerTimer = new BasicTimer(MBCommon.TimeType.Mission);
+      }
+
+      return false;
+    }
+
+    public void OnMatchResultsReady()
+    {
+      if (!this._match.IsPlayerParticipating)
+        InformationManager.AddQuickInformation(new TextObject("{=UBd0dEPp}Match is over", null), 0, null, "");
+      else if (this._match.IsPlayerTeamWinner)
+      {
+        if (this._isLastRound)
+          InformationManager.AddQuickInformation(new TextObject("{=wOqOQuJl}Round is over, your team survived the final round of the tournament.", null), 0, null, "");
+        else
+          InformationManager.AddQuickInformation(new TextObject("{=fkOYvnVG}Round is over, your team is qualified for the next stage of the tournament.", null), 0, null, "");
+      }
+      else
+        InformationManager.AddQuickInformation(new TextObject("{=MLyBN51z}Round is over, your team is disqualified from the tournament.", null), 0, null, "");
+    }
+
+    public void OnMatchEnded()
+    {
+      for (int i = base.Mission.Agents.Count - 1; i >= 0; i--)
+      {
+        base.Mission.Agents[i].FadeOut(true, false);
+      }
+      base.Mission.ClearCorpses(false);
+      base.Mission.Teams.Clear();
+      base.Mission.RemoveSpawnedItemsAndMissiles();
+      this._match = null;
+      this._endTimer = null;
+      this._cheerTimer = null;
+      this._isSimulated = false;
+    }
+
+    private void SpawnAgentWithRandomItems(TeamTournamentMember member, Team team, MatrixFrame frame)
+    {
+      frame.Strafe((float)MBRandom.RandomInt(-2, 2) * 1f);
+      frame.Advance((float)MBRandom.RandomInt(0, 2) * 1f);
+      var character = member.Character;
+      var agentBuildData = new AgentBuildData(new SimpleAgentOrigin(character, -1, null, member.Descriptor)).Team(team).InitialFrame(frame).Equipment(member.MatchEquipment).ClothingColor1(team.Color).Banner(team.Banner).Controller(character.IsPlayerCharacter ? Agent.ControllerType.Player : Agent.ControllerType.AI);
+      var agent = base.Mission.SpawnAgent(agentBuildData, false, 0);
+      if (character.IsPlayerCharacter)
+      {
+        agent.Health = (float)character.HeroObject.HitPoints;
+        base.Mission.PlayerTeam = team;
+      }
+      else
+      {
+        agent.AddController(typeof(FighterAgentController));
+        agent.SetWatchState(AgentAIStateFlagComponent.WatchState.Alarmed);
+      }
+      agent.WieldInitialWeapons(Agent.WeaponWieldActionType.InstantAfterPickUp);
+    }
+
+    private void AddRandomClothes(CultureObject culture, TeamTournamentMember member)
+    {
+      var randomBattleEquipment = member.Character.RandomBattleEquipment;
+      for (int i = 5; i < 10; i++)
+      {
+        var equipmentFromSlot = randomBattleEquipment.GetEquipmentFromSlot((EquipmentIndex)i);
+        if (equipmentFromSlot.Item != null)
+        {
+          member.MatchEquipment.AddEquipmentToSlotWithoutAgent((EquipmentIndex)i, equipmentFromSlot);
+        }
+      }
+    }
+
+    private bool IsTeamDead(TeamTournamentTeam team) => !this._aliveMembers.Any(x => x.Team == team);
+
+    private void AddScoreToRemainingTeams() => this._aliveTeams.ForEach(x => x.AddScore(1));
+
+    private void AddScoreToKillerTeam(int killerUniqueSeed)
+    {
+      this._aliveTeams.FirstOrDefault(x => x.Members.Any(m => m.IsCharWithDescriptor(killerUniqueSeed))).AddScore(1);
+    }
+
+    private void AddLastTeamScore()
+    {
+      this._aliveTeams.First().AddScore(_match.Teams.Count());
+    }
+
+    public override void OnAgentRemoved(Agent affectedAgent, Agent affectorAgent, AgentState agentState, KillingBlow killingBlow)
+    {
+      if (!this.IsMatchEnded() && affectorAgent != null && affectedAgent != affectorAgent && affectedAgent.IsHuman && affectorAgent.IsHuman)
+      {
+        var member = this._match.MatchMembers.FirstOrDefault(x => x.IsCharWithDescriptor(affectedAgent.Origin.UniqueSeed));
+
+        this._aliveMembers.Remove(member);
+
+        // apply score only if not on same team
+        if (affectedAgent.Team != affectorAgent.Team)
+          this.AddScoreToKillerTeam(affectorAgent.Origin.UniqueSeed);
+
+        if (this.IsTeamDead(member.Team))
+        {
+          this._aliveTeams.Remove(member.Team);
+
+          // give last team a bonus
+          if (this._aliveTeams.Count == 1)
+            this.AddLastTeamScore();
+        }
+      }
+    }
+
+    public override void OnScoreHit(
+      Agent affectedAgent,
+      Agent affectorAgent,
+      WeaponComponentData attackerWeapon,
+      bool isBlocked,
+      float damage,
+      float movementSpeedDamageModifier,
+      float hitDistance,
+      AgentAttackType attackType,
+      float shotDifficulty,
+      BoneBodyPartType victimHitBodyPart)
+    {
+      if (affectorAgent != null)
+      {
+        if (affectorAgent.Character != null && affectedAgent.Character != null)
+        {
+          if (damage > affectedAgent.HealthLimit)
+            damage = affectedAgent.HealthLimit;
+
+          this.EnemyHitReward(affectedAgent, affectorAgent, movementSpeedDamageModifier, shotDifficulty, attackerWeapon, XpShareForDamage * damage / affectedAgent.HealthLimit, damage);
+        }
+      }
+    }
+
+    private void EnemyHitReward(
+      Agent affectedAgent,
+      Agent affectorAgent,
+      float lastSpeedBonus,
+      float lastShotDifficulty,
+      WeaponComponentData lastAttackerWeapon,
+      float hitpointRatio,
+      float damageAmount)
+    {
+      CharacterObject affectedCharacter = (CharacterObject)affectedAgent.Character;
+      CharacterObject affectorCharacter = (CharacterObject)affectorAgent.Character;
+      if (affectedAgent.Origin != null && affectorAgent != null && affectorAgent.Origin != null)
+      {
+        SkillLevelingManager.OnCombatHit(affectorCharacter,
+          affectedCharacter,
+          null,
+          null,
+          lastSpeedBonus,
+          lastShotDifficulty,
+          lastAttackerWeapon,
+          hitpointRatio,
+          CombatXpModel.MissionTypeEnum.Tournament,
+          affectorAgent.MountAgent != null,
+          affectorAgent.Team == affectedAgent.Team,
+          false, damageAmount,
+          affectedAgent.Health < 1f);
+      }
+    }
+
+    public bool CheckIfIsThereAnyEnemies()
+    {
+      Team team = null;
+      foreach (var agent in Mission.Agents.Where(x => x.IsHuman && x.Team != null))
+      {
+        if (team == null)
+          team = agent.Team;
+        else if (team != agent.Team)
+          return true;
+      }
+      return false;
+    }
+
+    private void Simulate()
+    {
+      this._isSimulated = false;
+
+      if (base.Mission.Agents.Count == 0)
+      {
+        this._aliveMembers = new List<TeamTournamentMember>(this._match.MatchMembers);
+        this._aliveTeams = new List<TeamTournamentTeam>(this._match.Teams);
+      }
+
+      var player = this._aliveMembers.FirstOrDefault(x => x.IsPlayer);
+
+      // if player is still alive => player quit, remove and take teams score too
+      if (player != null)
+      {
+        foreach (var member in player.Team.Members)
+        {
+          member.ResetScore();
+          this._aliveMembers.Remove(member);
+        }
+        this._aliveTeams.Remove(player.Team);
+        player.Team?.ResetScore();
+        this.AddScoreToRemainingTeams();
+      }
+
+      var simAttacks = new Dictionary<TeamTournamentMember, Tuple<float, float>>();
+      foreach (var member in this._aliveMembers)
+      {
+        member.Character.GetSimulationAttackPower(out float item, out float item2, member.MatchEquipment);
+        simAttacks.Add(member, new Tuple<float, float>(item, item2));
+      }
+
+      int runningIndex = 0;
+      while (this._aliveMembers.Count() > 1 && this._aliveTeams.Count() > 1)
+      {
+        runningIndex = ++runningIndex % this._aliveMembers.Count();
+        var currentFighter = this._aliveMembers[runningIndex];
+        int nextIndex;
+
+        TeamTournamentMember nextFighter;
+        do
+        {
+          nextIndex = MBRandom.RandomInt(this._aliveMembers.Count);
+          nextFighter = this._aliveMembers[nextIndex];
+        }
+        while (currentFighter == nextFighter || currentFighter.Team == nextFighter.Team);
+
+        if (simAttacks[nextFighter].Item2 - simAttacks[currentFighter].Item1 > 0f)
+        {
+          simAttacks[nextFighter] = new Tuple<float, float>(simAttacks[nextFighter].Item1, simAttacks[nextFighter].Item2 - simAttacks[currentFighter].Item1);
+        }
+        else
+        {
+          simAttacks.Remove(nextFighter);
+          this._aliveMembers.Remove(nextFighter);
+
+          if (this.IsTeamDead(nextFighter.Team))
+          {
+            this._aliveTeams.Remove(nextFighter.Team);
+            this.AddScoreToRemainingTeams();
+          }
+
+          if (nextIndex < runningIndex)
+            runningIndex--;
+        }
+      }
+      this._isSimulated = true;
+    }
+
+    private bool IsThereAnyPlayerAgent() => Mission.MainAgent != null && base.Mission.MainAgent.IsActive() || Mission.Agents.Any(agent => agent.IsPlayerControlled);
+
+    public override InquiryData OnEndMissionRequest(out bool canPlayerLeave)
+    {
+      InquiryData result = null;
+      canPlayerLeave = true;
+      var missionBehaviour = Mission.Current.GetMissionBehaviour<TeamTournamentBehavior>();
+      if (this._match != null && missionBehaviour != null)
+      {
+        if (this._match.IsPlayerParticipating)
+        {
+          MBTextManager.SetTextVariable("SETTLEMENT_NAME", Hero.MainHero.CurrentSettlement.EncyclopediaLinkWithName, false);
+          if (this.IsThereAnyPlayerAgent())
+          {
+            if (base.Mission.IsPlayerCloseToAnEnemy(5f))
+            {
+              canPlayerLeave = false;
+              InformationManager.AddQuickInformation(GameTexts.FindText("str_can_not_retreat", null), 0, null, "");
+            }
+            else if (this.CheckIfIsThereAnyEnemies())
+            {
+              result = new InquiryData(GameTexts.FindText("str_tournament", null).ToString(), GameTexts.FindText("str_tournament_forfeit_game", null).ToString(), true, true, GameTexts.FindText("str_yes", null).ToString(), GameTexts.FindText("str_no", null).ToString(), new Action(missionBehaviour.SkipMatch), null, "");
+            }
+            else
+            {
+              this._forceEndMatch = true;
+              canPlayerLeave = false;
+            }
+          }
+          else if (this.CheckIfIsThereAnyEnemies())
+          {
+            result = new InquiryData(GameTexts.FindText("str_tournament", null).ToString(), GameTexts.FindText("str_tournament_skip", null).ToString(), true, true, GameTexts.FindText("str_yes", null).ToString(), GameTexts.FindText("str_no", null).ToString(), new Action(missionBehaviour.SkipMatch), null, "");
+          }
+          else
+          {
+            this._forceEndMatch = true;
+            canPlayerLeave = false;
+          }
+        }
+        else if (this.CheckIfIsThereAnyEnemies())
+        {
+          result = new InquiryData(GameTexts.FindText("str_tournament", null).ToString(), GameTexts.FindText("str_tournament_skip", null).ToString(), true, true, GameTexts.FindText("str_yes", null).ToString(), GameTexts.FindText("str_no", null).ToString(), new Action(missionBehaviour.SkipMatch), null, "");
+        }
+        else
+        {
+          this._forceEndMatch = true;
+          canPlayerLeave = false;
+        }
+      }
+      return result;
+    }
+
+    /// <summary>
+    /// just so we keep the interface intact, should never be called
+    /// </summary>
+    /// <param name="match"></param>
+    /// <param name="isLastRound"></param>
+    public void StartMatch(TournamentMatch match, bool isLastRound)
+    {
+      throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// just so we keep the interface intact, should never be called
+    /// </summary>
+    /// <param name="match"></param>
+    public void SkipMatch(TournamentMatch match)
+    {
+      throw new NotImplementedException();
+    }
+
+    private readonly CharacterObject _defaultWeaponTemplatesIdTeamSizeOne = MBObjectManager.Instance.GetObject<CharacterObject>("tournament_template_empire_one_participant_set_v1");
+    private readonly CharacterObject _defaultWeaponTemplatesIdTeamSizeTwo = MBObjectManager.Instance.GetObject<CharacterObject>("tournament_template_empire_two_participant_set_v1");
+    private readonly CharacterObject _defaultWeaponTemplatesIdTeamSizeFour = MBObjectManager.Instance.GetObject<CharacterObject>("tournament_template_empire_four_participant_set_v1");
+    private TeamTournamentMatch _match;
+    private bool _isLastRound;
+    private BasicTimer _endTimer;
+    private BasicTimer _cheerTimer;
+    private List<GameEntity> _spawnPoints;
+    private bool _isSimulated;
+    private bool _forceEndMatch;
+    private CultureObject _culture;
+    private List<TeamTournamentMember> _aliveMembers;
+    private List<TeamTournamentTeam> _aliveTeams;
+  }
+}

--- a/src/TeamTournament/TeamTournamentRound.cs
+++ b/src/TeamTournament/TeamTournamentRound.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.Core;
+
+namespace TournamentsEnhanced.TeamTournament
+{
+  public class TeamTournamentRound
+  {
+    public IEnumerable<TeamTournamentMatch> Matches { get => _matches; }
+    public int MatchCount { get => _matches.Count; }
+    public int CurrentMatchIndex { get; private set; }
+    public TeamTournamentMatch CurrentMatch => (this.CurrentMatchIndex >= this._matches.Count) ? null : this._matches[this.CurrentMatchIndex];
+    public IEnumerable<TeamTournamentTeam> Teams => Matches != null ? Matches.SelectMany(x => x.Teams) : null;
+
+    public TeamTournamentRound(int teamsInRound, int numberOfMatches, int numerOfWinnerTeams)
+    {
+      this.CurrentMatchIndex = 0;
+      _matches = new List<TeamTournamentMatch>(numberOfMatches);
+      for (var i = 0; i < numberOfMatches; i++)
+        this._matches.Add(new TeamTournamentMatch(teamsInRound / numberOfMatches, numerOfWinnerTeams));
+    }
+
+    public int AddTeam(TeamTournamentTeam team)
+    {
+      int matchNum;
+      int tryNum = 0;
+      do
+      {
+        if (tryNum++ == 64)
+        {
+          matchNum = this._matches.FindIndex(x => !x.IsFullMatch);
+          break;
+        }
+        matchNum = MBRandom.Random.Next(this._matches.Count);
+      } while (this._matches[matchNum].IsFullMatch);
+
+      this._matches[matchNum].AddTeam(team);
+      return matchNum;
+    }
+
+    public void EndMatch()
+    {
+      this.CurrentMatch?.End();
+      this.CurrentMatchIndex++;
+    }
+
+    private List<TeamTournamentMatch> _matches;
+  }
+}
+

--- a/src/TeamTournament/TeamTournamentTeam.cs
+++ b/src/TeamTournament/TeamTournamentTeam.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.Core;
+
+namespace TournamentsEnhanced.TeamTournament
+{
+  public class TeamTournamentTeam
+  {
+    private List<TeamTournamentMember> _members;
+    private int _score;
+    private TeamTournamentMember _leader;
+
+    public IEnumerable<TeamTournamentMember> Members { get => _members; }
+    public int Score { get => _score; }
+    public Banner TeamBanner { get; set; }
+    public uint TeamColor { get; set; }
+    public bool IsPlayerTeam => this.Members.Any(x => x.IsPlayer);
+
+    public TeamTournamentTeam(IEnumerable<TeamTournamentMember> members, Banner teamBanner = null, uint teamColor = 0, TeamTournamentMember leader = null)
+    {
+      _members = new List<TeamTournamentMember>(members);
+      this.TeamBanner = teamBanner;
+      this.TeamColor = teamColor;
+
+      foreach (var el in _members)
+        el.SetTeam(this);
+
+      this._leader = leader;
+    }
+
+    public void AddScore(int score)
+    {
+      _score += score;
+      Members.ToList().ForEach(x => x.AddScore(score));
+    }
+
+    public void ResetScore()
+    {
+      this._score = 0;
+      Members.ToList().ForEach(x => x.ResetScore());
+    }
+
+    public TeamTournamentMember GetTeamLeader()
+    {
+      if (this._leader != null)
+        return this._leader;
+
+      if (IsPlayerTeam)
+        return this.Members.First(x => x.IsPlayer);
+      else
+      {
+        return
+          this.Members.OrderByDescending(x => x.Character.GetPower()).FirstOrDefault(x => x.Character.IsHero)
+          ?? this.Members.OrderByDescending(x => x.Character.GetPower()).First();
+      }
+    }
+  }
+}

--- a/src/TeamTournament/ViewModels/TeamTournamentMatchVM.cs
+++ b/src/TeamTournament/ViewModels/TeamTournamentMatchVM.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SandBox.ViewModelCollection.Tournament.ViewModels;
+using TaleWorlds.Library;
+
+namespace TournamentsEnhanced.TeamTournament.ViewModels
+{
+  public class TeamTournamentMatchVM : ViewModel
+  {
+    public TeamTournamentMatch Match { get; private set; }
+    public IEnumerable<TeamTournamentTeamVM> Teams { get => _teams; }
+
+    public TeamTournamentMatchVM()
+    {
+      this.Team1 = new TeamTournamentTeamVM();
+      this.Team2 = new TeamTournamentTeamVM();
+      this.Team3 = new TeamTournamentTeamVM();
+      this.Team4 = new TeamTournamentTeamVM();
+      this._teams = new List<TeamTournamentTeamVM>
+      {
+        this.Team1,
+        this.Team2,
+        this.Team3,
+        this.Team4
+      };
+    }
+
+    public IEnumerable<TeamTournamentMemberVM> GetMatchMemberVMs() => Teams.SelectMany(x => x.Members);
+
+    public override void RefreshValues()
+    {
+      base.RefreshValues();
+      this._teams.ForEach(x => x.RefreshValues());
+    }
+
+    public void Initialize()
+    {
+      foreach (var tournamentTeamVM in this.Teams)
+      {
+        if (tournamentTeamVM.IsValid)
+          tournamentTeamVM.Initialize();
+      }
+    }
+
+    public void Initialize(TeamTournamentMatch match)
+    {
+      int index = 0;
+      this.Match = match;
+      this.IsValid = (this.Match != null);
+      this.Count = match.Teams.Count();
+
+      foreach (var team in match.Teams)
+        this._teams[index++].Initialize(team);
+
+      this.State = 0;
+    }
+
+    public void Refresh(bool forceRefresh)
+    {
+      if (forceRefresh)
+      {
+        OnPropertyChanged("Count");
+      }
+      for (int i = 0; i < this.Count; i++)
+      {
+        var tournamentTeamVM = this._teams[i];
+        if (forceRefresh)
+        {
+          OnPropertyChanged("Team" + i + 1);
+        }
+        tournamentTeamVM.Refresh();
+        for (int j = 0; j < tournamentTeamVM.Count; j++)
+        {
+          var teamMemberVM = tournamentTeamVM.Members.ElementAt(j);
+          teamMemberVM.Score = teamMemberVM.Member.Score.ToString();
+          teamMemberVM.IsQualifiedForNextRound = this.Match.Winners != null && this.Match.Winners.Any(x => x.Members.Contains(teamMemberVM.Member));
+        }
+      }
+    }
+
+    public void RefreshActiveMatch()
+    {
+      for (int i = 0; i < this.Count; i++)
+      {
+        var tournamentTeamVM = this._teams[i];
+        for (int j = 0; j < tournamentTeamVM.Count; j++)
+        {
+          var tournamentParticipantVM = tournamentTeamVM.Members.ElementAt(j);
+          tournamentParticipantVM.Score = tournamentParticipantVM.Member.Score.ToString();
+        }
+      }
+    }
+
+    public void Refresh(TeamTournamentMatchVM target)
+    {
+      OnPropertyChanged("Count");
+      int num = 0;
+      foreach (var tournamentTeamVM in from t in this.Teams
+                                       where t.IsValid
+                                       select t)
+      {
+        OnPropertyChanged("Team" + num + 1);
+        tournamentTeamVM.Refresh();
+        num++;
+      }
+    }
+
+    #region view properties
+
+    [DataSourceProperty]
+    public bool IsValid
+    {
+      get
+      {
+        return this._isValid;
+      }
+      set
+      {
+        if (value != this._isValid)
+        {
+          this._isValid = value;
+          OnPropertyChangedWithValue(value, "IsValid");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public int State
+    {
+      get
+      {
+        return this._state;
+      }
+      set
+      {
+        if (value != this._state)
+        {
+          this._state = value;
+          OnPropertyChangedWithValue(value, "State");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public int Count
+    {
+      get
+      {
+        return this._count;
+      }
+      set
+      {
+        if (value != this._count)
+        {
+          this._count = value;
+          OnPropertyChangedWithValue(value, "Count");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentTeamVM Team1
+    {
+      get
+      {
+        return this._team1;
+      }
+      set
+      {
+        if (value != this._team1)
+        {
+          this._team1 = value;
+          OnPropertyChangedWithValue(value, "Team1");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentTeamVM Team2
+    {
+      get
+      {
+        return this._team2;
+      }
+      set
+      {
+        if (value != this._team2)
+        {
+          this._team2 = value;
+          OnPropertyChangedWithValue(value, "Team2");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentTeamVM Team3
+    {
+      get
+      {
+        return this._team3;
+      }
+      set
+      {
+        if (value != this._team3)
+        {
+          this._team3 = value;
+          OnPropertyChangedWithValue(value, "Team3");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentTeamVM Team4
+    {
+      get
+      {
+        return this._team4;
+      }
+      set
+      {
+        if (value != this._team4)
+        {
+          this._team4 = value;
+          OnPropertyChangedWithValue(value, "Team4");
+        }
+      }
+    }
+    #endregion
+
+    private TeamTournamentTeamVM _team1;
+    private TeamTournamentTeamVM _team2;
+    private TeamTournamentTeamVM _team3;
+    private TeamTournamentTeamVM _team4;
+    private int _count = -1;
+    private int _state = -1;
+    private bool _isValid;
+    private List<TeamTournamentTeamVM> _teams;
+  }
+}

--- a/src/TeamTournament/ViewModels/TeamTournamentMemberVM.cs
+++ b/src/TeamTournament/ViewModels/TeamTournamentMemberVM.cs
@@ -35,7 +35,7 @@ namespace TournamentsEnhanced.TeamTournament.ViewModels
       this.IsInitialized = true;
       if (member != null)
       {
-        this.Name = member.Character.Name.ToString();
+        this.Name = member.Character.Name.ToString() + "'s Team";
         this.Character = new CharacterViewModel(CharacterViewModel.StanceTypes.CelebrateVictory);
         this.Character.FillFrom(member.Character, -1);
         this.Visual = new ImageIdentifierVM(CharacterCode.CreateFrom(member.Character));

--- a/src/TeamTournament/ViewModels/TeamTournamentMemberVM.cs
+++ b/src/TeamTournament/ViewModels/TeamTournamentMemberVM.cs
@@ -1,0 +1,239 @@
+﻿using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Core.ViewModelCollection;
+using TaleWorlds.Library;
+
+namespace TournamentsEnhanced.TeamTournament.ViewModels
+{
+  public class TeamTournamentMemberVM : ViewModel
+  {
+    public TeamTournamentMember Member { get; private set; }
+
+    public TeamTournamentMemberVM()
+    {
+      this._visual = new ImageIdentifierVM(ImageIdentifierType.Null);
+      this._character = new CharacterViewModel(CharacterViewModel.StanceTypes.CelebrateVictory);
+    }
+
+    public TeamTournamentMemberVM(TeamTournamentMember member) : this()
+    {
+      Refresh(member, Color.FromUint(member.Team.TeamColor));
+    }
+
+    public override void RefreshValues()
+    {
+      base.RefreshValues();
+      if (this.IsInitialized)
+        this.Refresh(this.Member, this.TeamColor);
+    }
+
+    public void Refresh(TeamTournamentMember member, Color teamColor)
+    {
+      this.Member = member;
+      this.TeamColor = teamColor;
+      this.State = member == null ? 0 : (member.IsPlayer ? 2 : 1);
+      this.IsInitialized = true;
+      if (member != null)
+      {
+        this.Name = member.Character.Name.ToString();
+        this.Character = new CharacterViewModel(CharacterViewModel.StanceTypes.CelebrateVictory);
+        this.Character.FillFrom(member.Character, -1);
+        this.Visual = new ImageIdentifierVM(CharacterCode.CreateFrom(member.Character));
+        this.IsValid = true;
+        this.IsMainHero = member.IsPlayer;
+      }
+    }
+
+    public void Refresh()
+    {
+      OnPropertyChanged("Name");
+      OnPropertyChanged("Visual");
+      OnPropertyChanged("Score");
+      OnPropertyChanged("State");
+      OnPropertyChanged("TeamColor");
+      OnPropertyChanged("IsDead");
+      this.IsMainHero = (this.Member != null && this.Member.IsPlayer);
+    }
+
+    #region view properties
+    [DataSourceProperty]
+    public bool IsInitialized
+    {
+      get => this._isInitialized;
+      set
+      {
+        if (value != this._isInitialized)
+        {
+          this._isInitialized = value;
+          OnPropertyChangedWithValue(value, "IsInitialized");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public bool IsValid
+    {
+      get => this._isValid;
+      set
+      {
+        if (value != this._isValid)
+        {
+          this._isValid = value;
+          OnPropertyChangedWithValue(value, "IsValid");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public bool IsDead
+    {
+      get => this._isDead;
+      set
+      {
+        if (value != this._isDead)
+        {
+          this._isDead = value;
+          OnPropertyChangedWithValue(value, "IsDead");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public bool IsMainHero
+    {
+      get => this._isMainHero;
+      set
+      {
+        if (value != this._isMainHero)
+        {
+          this._isMainHero = value;
+          OnPropertyChangedWithValue(value, "IsMainHero");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public Color TeamColor
+    {
+      get => this._teamColor;
+      set
+      {
+        if (value != this._teamColor)
+        {
+          this._teamColor = value;
+          OnPropertyChangedWithValue(value, "TeamColor");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public ImageIdentifierVM Visual
+    {
+      get => this._visual;
+      set
+      {
+        if (value != this._visual)
+        {
+          this._visual = value;
+          OnPropertyChangedWithValue(value, "Visual");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public int State
+    {
+      get => this._state;
+      set
+      {
+        if (value != this._state)
+        {
+          this._state = value;
+          OnPropertyChangedWithValue(value, "State");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public bool IsQualifiedForNextRound
+    {
+      get => this._isQualifiedForNextRound;
+      set
+      {
+        if (value != this._isQualifiedForNextRound)
+        {
+          this._isQualifiedForNextRound = value;
+          OnPropertyChangedWithValue(value, "IsQualifiedForNextRound");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string Score
+    {
+      get => this._score;
+      set
+      {
+        if (value != this._score)
+        {
+          this._score = value;
+          OnPropertyChangedWithValue(value, "Score");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string Name
+    {
+      get => this._name;
+      set
+      {
+        if (value != this._name)
+        {
+          this._name = value;
+          OnPropertyChangedWithValue(value, "Name");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public CharacterViewModel Character
+    {
+      get => this._character;
+      set
+      {
+        if (value != this._character)
+        {
+          this._character = value;
+          OnPropertyChangedWithValue(value, "Character");
+        }
+      }
+    }
+    #endregion 
+
+    private bool _isInitialized;
+    private bool _isValid;
+    private string _name = "";
+    private string _score = "-";
+    private bool _isQualifiedForNextRound;
+    private int _state = -1;
+    private ImageIdentifierVM _visual;
+    private Color _teamColor;
+    private bool _isDead;
+    private bool _isMainHero;
+    private CharacterViewModel _character;
+
+#pragma warning disable IDE0051 // Remove unused private members
+    /// <summary>
+    /// DO NOT REMOVE CALLED DYNAMICALLY
+    /// </summary>
+    private void ExecuteOpenEncyclopedia()
+    {
+      if (this.Member != null && this.Member.Character != null)
+      {
+        Campaign.Current.EncyclopediaManager.GoToLink(this.Member.Character.EncyclopediaLink);
+      }
+    }
+#pragma warning restore IDE0051 // Remove unused private members
+  }
+}

--- a/src/TeamTournament/ViewModels/TeamTournamentRoundVM.cs
+++ b/src/TeamTournament/ViewModels/TeamTournamentRoundVM.cs
@@ -1,0 +1,269 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using SandBox.ViewModelCollection.Tournament.ViewModels;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using static TaleWorlds.CampaignSystem.SandBox.Source.TournamentGames.TournamentMatch;
+
+namespace TournamentsEnhanced.TeamTournament.ViewModels
+{
+  public class TeamTournamentRoundVM : ViewModel
+  {
+    public TeamTournamentRound Round { get; private set; }
+    public bool IsFinished => MatchVMs.All(m => m.Match.State == MatchState.Finished);
+    public IEnumerable<TeamTournamentMatchVM> MatchVMs { get => _matchVMs; }
+
+    public TeamTournamentRoundVM()
+    {
+      this.Match1 = new TeamTournamentMatchVM();
+      this.Match2 = new TeamTournamentMatchVM();
+      this.Match3 = new TeamTournamentMatchVM();
+      this.Match4 = new TeamTournamentMatchVM();
+      this.Match5 = new TeamTournamentMatchVM();
+      this.Match6 = new TeamTournamentMatchVM();
+      this.Match7 = new TeamTournamentMatchVM();
+      this.Match8 = new TeamTournamentMatchVM();
+      this._matchVMs = new List<TeamTournamentMatchVM>
+      {
+        this.Match1,
+        this.Match2,
+        this.Match3,
+        this.Match4,
+        this.Match5,
+        this.Match6,
+        this.Match7,
+        this.Match8
+      };
+    }
+
+    public override void RefreshValues()
+    {
+      base.RefreshValues();
+      this._matchVMs.ForEach(x => x.RefreshValues());
+    }
+
+    public void Initialize() => this._matchVMs.ForEach(x => x.Initialize());
+
+    public void Initialize(TeamTournamentRound round, TextObject name)
+    {
+      this.Initialize(round);
+      this.Name = name.ToString();
+    }
+
+    public void Initialize(TeamTournamentRound round)
+    {
+      this.IsValid = round != null;
+
+      if (round != null)
+      {
+        this.Round = round;
+        this.Count = round.MatchCount; // count of machtes
+        var index = 0;
+        foreach (var match in round.Matches)
+          _matchVMs[index++].Initialize(match);
+      }
+    }
+
+    #region view properties
+    [DataSourceProperty]
+    public bool IsValid
+    {
+      get
+      {
+        return this._isValid;
+      }
+      set
+      {
+        if (value != this._isValid)
+        {
+          this._isValid = value;
+          OnPropertyChangedWithValue(value, "IsValid");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string Name
+    {
+      get
+      {
+        return this._name;
+      }
+      set
+      {
+        if (value != this._name)
+        {
+          this._name = value;
+          OnPropertyChangedWithValue(value, "Name");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public int Count
+    {
+      get
+      {
+        return this._count;
+      }
+      set
+      {
+        if (value != this._count)
+        {
+          this._count = value;
+          OnPropertyChangedWithValue(value, "Count");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMatchVM Match1
+    {
+      get
+      {
+        return this._match1;
+      }
+      set
+      {
+        if (value != this._match1)
+        {
+          this._match1 = value;
+          OnPropertyChangedWithValue(value, "Match1");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMatchVM Match2
+    {
+      get
+      {
+        return this._match2;
+      }
+      set
+      {
+        if (value != this._match2)
+        {
+          this._match2 = value;
+          OnPropertyChangedWithValue(value, "Match2");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMatchVM Match3
+    {
+      get
+      {
+        return this._match3;
+      }
+      set
+      {
+        if (value != this._match3)
+        {
+          this._match3 = value;
+          OnPropertyChangedWithValue(value, "Match3");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMatchVM Match4
+    {
+      get
+      {
+        return this._match4;
+      }
+      set
+      {
+        if (value != this._match4)
+        {
+          this._match4 = value;
+          OnPropertyChangedWithValue(value, "Match4");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMatchVM Match5
+    {
+      get
+      {
+        return this._match5;
+      }
+      set
+      {
+        if (value != this._match5)
+        {
+          this._match5 = value;
+          OnPropertyChangedWithValue(value, "Match5");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMatchVM Match6
+    {
+      get
+      {
+        return this._match6;
+      }
+      set
+      {
+        if (value != this._match6)
+        {
+          this._match6 = value;
+          OnPropertyChangedWithValue(value, "Match6");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMatchVM Match7
+    {
+      get
+      {
+        return this._match7;
+      }
+      set
+      {
+        if (value != this._match7)
+        {
+          this._match7 = value;
+          OnPropertyChangedWithValue(value, "Match7");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMatchVM Match8
+    {
+      get
+      {
+        return this._match8;
+      }
+      set
+      {
+        if (value != this._match8)
+        {
+          this._match8 = value;
+          OnPropertyChangedWithValue(value, "Match8");
+        }
+      }
+    }
+    #endregion view properties
+
+    private TeamTournamentMatchVM _match1;
+    private TeamTournamentMatchVM _match2;
+    private TeamTournamentMatchVM _match3;
+    private TeamTournamentMatchVM _match4;
+    private TeamTournamentMatchVM _match5;
+    private TeamTournamentMatchVM _match6;
+    private TeamTournamentMatchVM _match7;
+    private TeamTournamentMatchVM _match8;
+    private int _count = -1;
+    private string _name;
+    private bool _isValid;
+    private List<TeamTournamentMatchVM> _matchVMs;
+  }
+}

--- a/src/TeamTournament/ViewModels/TeamTournamentTeamVM.cs
+++ b/src/TeamTournament/ViewModels/TeamTournamentTeamVM.cs
@@ -1,0 +1,256 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.Library;
+using TournamentsEnhanced.TeamTournament;
+using TournamentsEnhanced.TeamTournament.ViewModels;
+
+namespace SandBox.ViewModelCollection.Tournament.ViewModels
+{
+  public class TeamTournamentTeamVM : ViewModel
+  {
+    public IEnumerable<TeamTournamentMemberVM> Members { get => _members; }
+    public TeamTournamentTeam Team { get; private set; }
+
+    public TeamTournamentTeamVM()
+    {
+      this.Participant1 = new TeamTournamentMemberVM();
+      this.Participant2 = new TeamTournamentMemberVM();
+      this.Participant3 = new TeamTournamentMemberVM();
+      this.Participant4 = new TeamTournamentMemberVM();
+      this.Participant5 = new TeamTournamentMemberVM();
+      this.Participant6 = new TeamTournamentMemberVM();
+      this.Participant7 = new TeamTournamentMemberVM();
+      this.Participant8 = new TeamTournamentMemberVM();
+      _members = new List<TeamTournamentMemberVM>
+      {
+        this.Participant1,
+        this.Participant2,
+        this.Participant3,
+        this.Participant4,
+        this.Participant5,
+        this.Participant6,
+        this.Participant7,
+        this.Participant8
+      };
+    }
+
+    public IEnumerable<TeamTournamentMemberVM> GetMembers() => this.Members.Where(x => x.IsValid);
+
+    public TeamTournamentMemberVM GetTeamLeader() => Members.FirstOrDefault(x => x.Member == Team.GetTeamLeader());
+
+    public override void RefreshValues()
+    {
+      base.RefreshValues();
+      this._members.ForEach(x => x.RefreshValues());
+    }
+
+    public void Initialize()
+    {
+      this.IsValid = this.Team != null;
+
+      for (var i = 0; Team != null && i < this.Count; i++)
+        this._members[i].Refresh(Team.Members.ElementAtOrDefault(i), Color.FromUint(this.Team.TeamColor));
+    }
+
+    public void Initialize(TeamTournamentTeam team)
+    {
+      this.Team = team;
+      this.Count = team.Members.Count();
+      this.Initialize();
+    }
+
+    public void Refresh()
+    {
+      this.IsValid = (this.Team != null);
+      OnPropertyChanged("Count");
+
+      int num = 0;
+      foreach (var member in this.Members.Where(x => x.IsValid))
+      {
+        OnPropertyChanged("Participant" + num++);
+        member.Refresh();
+      }
+    }
+
+    #region view properties
+    [DataSourceProperty]
+    public bool IsValid
+    {
+      get => _isValid;
+      set
+      {
+        if (value != this._isValid)
+        {
+          this._isValid = value;
+          OnPropertyChangedWithValue(value, "IsValid");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public int Score
+    {
+      get => this._score;
+      set
+      {
+        if (value != this._score)
+        {
+          this._score = value;
+          OnPropertyChangedWithValue(value, "Score");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMemberVM Participant1
+    {
+      get => this._participant1;
+      set
+      {
+        if (value != this._participant1)
+        {
+          this._participant1 = value;
+          OnPropertyChangedWithValue(value, "Participant1");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMemberVM Participant2
+    {
+      get => this._participant2;
+      set
+      {
+        if (value != this._participant2)
+        {
+          this._participant2 = value;
+          OnPropertyChangedWithValue(value, "Participant2");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMemberVM Participant3
+    {
+      get => this._participant3;
+      set
+      {
+        if (value != this._participant3)
+        {
+          this._participant3 = value;
+          OnPropertyChangedWithValue(value, "Participant3");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMemberVM Participant4
+    {
+      get
+      {
+        return this._participant4;
+      }
+      set
+      {
+        if (value != this._participant4)
+        {
+          this._participant4 = value;
+          OnPropertyChangedWithValue(value, "Participant4");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMemberVM Participant5
+    {
+      get
+      {
+        return this._participant5;
+      }
+      set
+      {
+        if (value != this._participant5)
+        {
+          this._participant5 = value;
+          OnPropertyChangedWithValue(value, "Participant5");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMemberVM Participant6
+    {
+      get => this._participant6;
+      set
+      {
+        if (value != this._participant6)
+        {
+          this._participant6 = value;
+          OnPropertyChangedWithValue(value, "Participant6");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMemberVM Participant7
+    {
+      get
+      {
+        return this._participant7;
+      }
+      set
+      {
+        if (value != this._participant7)
+        {
+          this._participant7 = value;
+          OnPropertyChangedWithValue(value, "Participant7");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMemberVM Participant8
+    {
+      get
+      {
+        return this._participant8;
+      }
+      set
+      {
+        if (value != this._participant8)
+        {
+          this._participant8 = value;
+          OnPropertyChangedWithValue(value, "Participant8");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public int Count
+    {
+      get => this._count;
+      set
+      {
+        if (value != this._count)
+        {
+          this._count = value;
+          OnPropertyChangedWithValue(value, "Count");
+        }
+      }
+    }
+    #endregion
+
+    private int _count = -1;
+    private TeamTournamentMemberVM _participant1;
+    private TeamTournamentMemberVM _participant2;
+    private TeamTournamentMemberVM _participant3;
+    private TeamTournamentMemberVM _participant4;
+    private TeamTournamentMemberVM _participant5;
+    private TeamTournamentMemberVM _participant6;
+    private TeamTournamentMemberVM _participant7;
+    private TeamTournamentMemberVM _participant8;
+    private int _score;
+    private bool _isValid;
+    private List<TeamTournamentMemberVM> _members;
+  }
+}

--- a/src/TeamTournament/ViewModels/TeamTournamentTeamVM.cs
+++ b/src/TeamTournament/ViewModels/TeamTournamentTeamVM.cs
@@ -47,15 +47,13 @@ namespace SandBox.ViewModelCollection.Tournament.ViewModels
     public void Initialize()
     {
       this.IsValid = this.Team != null;
-
-      for (var i = 0; Team != null && i < this.Count; i++)
-        this._members[i].Refresh(Team.Members.ElementAtOrDefault(i), Color.FromUint(this.Team.TeamColor));
+      this._members[0].Refresh(Team.GetTeamLeader(), Color.FromUint(this.Team.TeamColor));
     }
 
     public void Initialize(TeamTournamentTeam team)
     {
       this.Team = team;
-      this.Count = team.Members.Count();
+      this.Count = 1;
       this.Initialize();
     }
 

--- a/src/TeamTournament/ViewModels/TeamTournamentVM.cs
+++ b/src/TeamTournament/ViewModels/TeamTournamentVM.cs
@@ -1,0 +1,902 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SandBox.ViewModelCollection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using TaleWorlds.MountAndBlade;
+
+namespace TournamentsEnhanced.TeamTournament.ViewModels
+{
+  public class TeamTournamentVM : ViewModel
+  {
+    public Action DisableUI { get; }
+    public TeamTournamentBehavior Tournament { get; }
+
+    public TeamTournamentVM(Action disableUI, TeamTournamentBehavior tournamentBehavior)
+    {
+      this.DisableUI = disableUI;
+      this.CurrentMatch = new TeamTournamentMatchVM();
+
+      this.Round1 = new TeamTournamentRoundVM();
+      this.Round2 = new TeamTournamentRoundVM();
+      this.Round3 = new TeamTournamentRoundVM();
+      this.Round4 = new TeamTournamentRoundVM();
+
+      this._rounds = new List<TeamTournamentRoundVM>
+      {
+        this.Round1,
+        this.Round2,
+        this.Round3,
+        this.Round4
+      };
+
+      this._tournamentWinner = new TeamTournamentMemberVM();
+      this.Tournament = tournamentBehavior;
+      this.WinnerIntro = GameTexts.FindText("str_tournament_winner_intro", null).ToString();
+      this.BattleRewards = new MBBindingList<TournamentRewardVM>();
+
+      for (int i = 0; i < this.Tournament.Rounds.Length; i++)
+        this._rounds[i].Initialize(this.Tournament.Rounds[i], GameTexts.FindText("str_tournament_round", i.ToString()));
+
+
+      this.Refresh();
+
+      this.Tournament.TournamentEnd += this.OnTournamentEnd;
+      this.Tournament.MatchEnd += this.OnMatchEnd;
+
+      this.PrizeVisual = (this.HasPrizeItem ? new ImageIdentifierVM(this.Tournament.TournamentGame.Prize) : new ImageIdentifierVM(ImageIdentifierType.Null));
+      this.RefreshValues();
+    }
+
+    private void OnMatchEnd(TeamTournamentMatch match)
+    {
+      if (ActiveRoundIndex < this._rounds.Count + 1 && this.Tournament.NextRound != null)
+      {
+        this._rounds[ActiveRoundIndex + 1].Initialize(this.Tournament.NextRound);
+        this.RefreshValues();
+      }
+    }
+
+    public override void RefreshValues()
+    {
+      base.RefreshValues();
+
+      this.LeaveText = GameTexts.FindText("str_tournament_leave", null).ToString();
+      this.SkipRoundText = GameTexts.FindText("str_tournament_skip_round", null).ToString();
+      this.WatchRoundText = GameTexts.FindText("str_tournament_watch_round", null).ToString();
+      this.JoinTournamentText = GameTexts.FindText("str_tournament_join_tournament", null).ToString();
+      this.BetText = GameTexts.FindText("str_bet", null).ToString();
+      this.AcceptText = GameTexts.FindText("str_accept", null).ToString();
+      this.CancelText = GameTexts.FindText("str_cancel", null).ToString();
+      this.TournamentWinnerTitle = GameTexts.FindText("str_tournament_winner_title", null).ToString();
+      this.BetTitleText = GameTexts.FindText("str_wager", null).ToString();
+      GameTexts.SetVariable("MAX_AMOUNT", this.Tournament.GetMaximumBet());
+      GameTexts.SetVariable("GOLD_ICON", "{=!}<img src=\"Icons\\Coin@2x\">");
+      this.BetDescriptionText = GameTexts.FindText("str_tournament_bet_description", null).ToString();
+      this.TournamentPrizeText = GameTexts.FindText("str_tournament_prize", null).ToString();
+      this.PrizeItemName = this.Tournament.TournamentGame.Prize.Name.ToString();
+      MBTextManager.SetTextVariable("SETTLEMENT_NAME", this.Tournament.Settlement.Name, false);
+      this.TournamentTitle = GameTexts.FindText("str_tournament", null).ToString();
+      this.CurrentWagerText = GameTexts.FindText("str_tournament_current_wager", null).ToString();
+
+      if (this._round1 != null)
+        this._round1.RefreshValues();
+      if (this._round2 != null)
+        this._round2.RefreshValues();
+      if (_round3 != null)
+        _round3.RefreshValues();
+      if (this._round4 != null)
+        this._round4.RefreshValues();
+      if (this._currentMatch != null)
+        this._currentMatch.RefreshValues();
+      if (this._tournamentWinner != null)
+        this._tournamentWinner.RefreshValues();
+    }
+
+    private void RefreshBetProperties()
+    {
+      TextObject textObject = new TextObject("{=L9GnQvsq}Stake: {BETTED_DENARS}", null);
+      textObject.SetTextVariable("BETTED_DENARS", this.Tournament.BettedDenars);
+      this.BettedDenarsText = textObject.ToString();
+      TextObject textObject2 = new TextObject("{=xzzSaN4b}Expected: {OVERALL_EXPECTED_DENARS}", null);
+      textObject2.SetTextVariable("OVERALL_EXPECTED_DENARS", this.Tournament.OverallExpectedDenars);
+      this.OverallExpectedDenarsText = textObject2.ToString();
+      TextObject textObject3 = new TextObject("{=yF5fpwNE}Total: {TOTAL}", null);
+      textObject3.SetTextVariable("TOTAL", this.Tournament.PlayerDenars);
+      this.TotalDenarsText = textObject3.ToString();
+      OnPropertyChanged("IsBetButtonEnabled");
+      this.MaximumBetValue = Math.Min(this.Tournament.GetMaximumBet() - this._thisRoundBettedAmount, Hero.MainHero.Gold);
+      GameTexts.SetVariable("NORMALIZED_EXPECTED_GOLD", (int)(this.Tournament.BetOdd * 100f));
+      GameTexts.SetVariable("GOLD_ICON", "{=!}<img src=\"Icons\\Coin@2x\">");
+      this.BetOddsText = GameTexts.FindText("str_tournament_bet_odd", null).ToString();
+    }
+
+    private void OnNewRoundStarted(int prevRoundIndex, int currentRoundIndex)
+    {
+      this._isPlayerParticipating = this.Tournament.IsPlayerParticipating;
+      this._thisRoundBettedAmount = 0;
+    }
+
+    public void Refresh()
+    {
+      this.IsCurrentMatchActive = false;
+      CurrentMatch = _rounds[Tournament.CurrentRoundIndex].MatchVMs.FirstOrDefault(m => m.IsValid && m.Match == Tournament.CurrentMatch);
+      this.ActiveRoundIndex = this.Tournament.CurrentRoundIndex;
+      this.CanPlayerJoin = this.PlayerCanJoinMatch();
+      OnPropertyChanged("IsTournamentIncomplete");
+      OnPropertyChanged("InitializationOver");
+      OnPropertyChanged("IsBetButtonEnabled");
+      this.HasPrizeItem = (this.Tournament.TournamentGame.Prize != null && !this.IsOver);
+    }
+
+    /// <summary>
+    /// TODO: make some better team winning interface
+    ///       for now vanilla view with team-leader as winner
+    /// </summary>
+    private void OnTournamentEnd()
+    {
+      var winnerTeams = this.Tournament.LastMatch.Teams.OrderByDescending(x => x.Score).ToList();
+      var firstTeamLeader = new TeamTournamentMemberVM(winnerTeams.ElementAt(0).GetTeamLeader());
+      var secondTeamLeader = new TeamTournamentMemberVM(winnerTeams.ElementAt(1).GetTeamLeader());
+      this.TournamentWinner = firstTeamLeader;
+
+      if (this.TournamentWinner.IsMainHero)
+      {
+        GameTexts.SetVariable("TOURNAMENT_FINAL_OPPONENT", $"{(firstTeamLeader == this.TournamentWinner ? secondTeamLeader : firstTeamLeader).Name}'s Team");
+        this.WinnerIntro = GameTexts.FindText("str_tournament_result_won", null).ToString();
+
+        if (this.Tournament.TournamentGame.TournamentWinRenown > 0f)
+        {
+          GameTexts.SetVariable("RENOWN", this.Tournament.TournamentGame.TournamentWinRenown.ToString("F1"));
+          this.BattleRewards.Add(new TournamentRewardVM(GameTexts.FindText("str_tournament_renown", null).ToString()));
+        }
+
+        if (this.Tournament.TournamentGame.Prize != null)
+        {
+          GameTexts.SetVariable("REWARD", this.Tournament.TournamentGame.Prize.Name.ToString());
+          this.BattleRewards.Add(new TournamentRewardVM(GameTexts.FindText("str_tournament_reward", null).ToString(), new ImageIdentifierVM(this.Tournament.TournamentGame.Prize)));
+        }
+
+        if (this.Tournament.OverallExpectedDenars > 0)
+        {
+          GameTexts.SetVariable("BET", this.Tournament.OverallExpectedDenars.ToString());
+          this.BattleRewards.Add(new TournamentRewardVM(GameTexts.FindText("str_tournament_bet", null).ToString()));
+        }
+      }
+      else if (firstTeamLeader.IsMainHero || secondTeamLeader.IsMainHero)
+      {
+        GameTexts.SetVariable("TOURNAMENT_FINAL_OPPONENT", $"{(firstTeamLeader == this.TournamentWinner ? firstTeamLeader : secondTeamLeader).Name}'s Team");
+        this.WinnerIntro = GameTexts.FindText("str_tournament_result_eliminated_at_final", null).ToString();
+      }
+      else
+      {
+        GameTexts.SetVariable("TOURNAMENT_FINAL_PARTICIPANT_A", $"{(firstTeamLeader == this.TournamentWinner ? firstTeamLeader : secondTeamLeader).Name}'s Team");
+        GameTexts.SetVariable("TOURNAMENT_FINAL_PARTICIPANT_B", $"{(firstTeamLeader == this.TournamentWinner ? secondTeamLeader : firstTeamLeader).Name}'s Team");
+
+        if (this._isPlayerParticipating)
+        {
+          GameTexts.SetVariable("TOURNAMENT_ELIMINATED_ROUND", this.Tournament.PlayerTeamLostAtRound + 1);
+          this.WinnerIntro = GameTexts.FindText("str_tournament_result_eliminated", null).ToString();
+        }
+        else
+          this.WinnerIntro = GameTexts.FindText("str_tournament_result_spectator", null).ToString();
+      }
+      this.IsOver = true;
+    }
+
+    private bool PlayerCanJoinMatch()
+    {
+      if (this.IsTournamentIncomplete)
+        return this.Tournament.CurrentMatch.IsPlayerParticipating;
+
+      return false;
+    }
+
+    public void OnAgentRemoved(Agent agent)
+    {
+      if (this.IsCurrentMatchActive && agent.IsHuman)
+      {
+        var member = GetMemberForSeed(agent.Origin.UniqueSeed);
+        if (member != null)
+          member.IsDead = true;
+      }
+    }
+
+    private TeamTournamentMemberVM GetMemberForSeed(int seed)
+    {
+      return this.CurrentMatch.GetMatchMemberVMs().FirstOrDefault(x => x.Member != null && x.Member.Descriptor.CompareTo(seed) == 0);
+    }
+
+    #region view commands
+#pragma warning disable IDE0051 // Remove unused private members
+    /// <summary>
+    /// DO NOT REMOVE
+    /// </summary>
+    private void ExecuteShowPrizeItemTooltip()
+
+    {
+      if (this.HasPrizeItem)
+      {
+        InformationManager.AddTooltipInformation(typeof(ItemObject), new object[]
+        {
+          new EquipmentElement(this.Tournament.TournamentGame.Prize, null)
+        });
+      }
+    }
+
+    /// <summary>
+    /// DO NOT REMOVE
+    /// </summary>
+    private void ExecuteHidePrizeItemTooltip()
+    {
+      InformationManager.HideInformations();
+    }
+
+    /// <summary>
+    /// DO NOT REMOVE
+    /// </summary>
+    private void ExecuteBet()
+    {
+      this._thisRoundBettedAmount += this.WageredDenars;
+      this.Tournament.PlaceABet(this.WageredDenars);
+      this.RefreshBetProperties();
+    }
+
+    /// <summary>
+    /// DO NOT REMOVE
+    /// </summary>
+    private void ExecuteJoinTournament()
+    {
+      if (this.PlayerCanJoinMatch())
+      {
+        this.Tournament.StartMatch();
+        this.IsCurrentMatchActive = true;
+        this.CurrentMatch.Refresh(true);
+        this.CurrentMatch.State = 3;
+        this.DisableUI();
+        this.IsCurrentMatchActive = true;
+      }
+    }
+
+    /// <summary>
+    /// DO NOT REMOVE
+    /// </summary>
+    private void ExecuteSkipRound()
+    {
+      if (this.IsTournamentIncomplete)
+      {
+        this.Tournament.SkipMatch();
+      }
+      this.Refresh();
+    }
+
+    /// <summary>
+    /// DO NOT REMOVE
+    /// </summary>
+    private void ExecuteWatchRound()
+    {
+      if (!this.PlayerCanJoinMatch())
+      {
+        this.Tournament.StartMatch();
+        this.IsCurrentMatchActive = true;
+        this.CurrentMatch.Refresh(true);
+        this.CurrentMatch.State = 3;
+        this.DisableUI();
+        this.IsCurrentMatchActive = true;
+      }
+    }
+
+    /// <summary>
+    /// DO NOT REMOVE
+    /// </summary>
+    private void ExecuteLeave()
+    {
+      if (this.CurrentMatch != null)
+      {
+        InformationManager.ShowInquiry(new InquiryData(
+          GameTexts.FindText("str_forfeit", null).ToString(),
+          new TextObject("Are you sure?").ToString(),
+          true,
+          true,
+          GameTexts.FindText("str_yes", null).ToString(),
+          GameTexts.FindText("str_no", null).ToString(),
+          this.ExitFinishTournament,
+          null),
+        true);
+      }
+      Mission.Current.EndMission();
+    }
+
+    private void ExitFinishTournament()
+    {
+      Campaign.Current.TournamentManager.ResolveTournament(this.Tournament.TournamentGame, Settlement.CurrentSettlement.Town);
+      Mission.Current.EndMission();
+    }
+
+#pragma warning restore IDE0051 // Remove unused private members
+    #endregion
+
+    #region view properties
+    [DataSourceProperty]
+    public string TournamentWinnerTitle
+    {
+      get => this._tournamentWinnerTitle;
+      set
+      {
+        if (value != this._tournamentWinnerTitle)
+        {
+          this._tournamentWinnerTitle = value;
+          OnPropertyChangedWithValue(value, "TournamentWinnerTitle");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMemberVM TournamentWinner
+    {
+      get => this._tournamentWinner;
+      set
+      {
+        if (value != this._tournamentWinner)
+        {
+          this._tournamentWinner = value;
+          OnPropertyChangedWithValue(value, "TournamentWinner");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public int MaximumBetValue
+    {
+      get => this._maximumBetValue;
+      set
+      {
+        if (value != this._maximumBetValue)
+        {
+          this._maximumBetValue = value;
+          OnPropertyChangedWithValue(value, "MaximumBetValue");
+          this._wageredDenars = -1;
+          this.WageredDenars = 0;
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public bool IsBetButtonEnabled => this.PlayerCanJoinMatch() && this.Tournament.GetMaximumBet() > this._thisRoundBettedAmount && Hero.MainHero.Gold > 0;
+
+    [DataSourceProperty]
+    public string BetText
+    {
+      get => this._betText;
+      set
+      {
+        if (value != this._betText)
+        {
+          this._betText = value;
+          OnPropertyChangedWithValue(value, "BetText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string BetTitleText
+    {
+      get => this._betTitleText;
+      set
+      {
+        if (value != this._betTitleText)
+        {
+          this._betTitleText = value;
+          OnPropertyChangedWithValue(value, "BetTitleText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string CurrentWagerText
+    {
+      get => this._currentWagerText;
+      set
+      {
+        if (value != this._currentWagerText)
+        {
+          this._currentWagerText = value;
+          OnPropertyChangedWithValue(value, "CurrentWagerText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string BetDescriptionText
+    {
+      get => this._betDescriptionText;
+      set
+      {
+        if (value != this._betDescriptionText)
+        {
+          this._betDescriptionText = value;
+          OnPropertyChangedWithValue(value, "BetDescriptionText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public ImageIdentifierVM PrizeVisual
+    {
+      get => this._prizeVisual;
+      set
+      {
+        if (value != this._prizeVisual)
+        {
+          this._prizeVisual = value;
+          OnPropertyChangedWithValue(value, "PrizeVisual");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string PrizeItemName
+    {
+      get => this._prizeItemName;
+      set
+      {
+        if (value != this._prizeItemName)
+        {
+          this._prizeItemName = value;
+          OnPropertyChangedWithValue(value, "PrizeItemName");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string TournamentPrizeText
+    {
+      get => this._tournamentPrizeText;
+      set
+      {
+        if (value != this._tournamentPrizeText)
+        {
+          this._tournamentPrizeText = value;
+          OnPropertyChangedWithValue(value, "TournamentPrizeText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public int WageredDenars
+    {
+      get => this._wageredDenars;
+      set
+      {
+        if (value != this._wageredDenars)
+        {
+          this._wageredDenars = value;
+          OnPropertyChangedWithValue(value, "WageredDenars");
+          this.ExpectedBetDenars = ((this._wageredDenars == 0) ? 0 : this.Tournament.GetExpectedDenarsForBet(this._wageredDenars));
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public int ExpectedBetDenars
+    {
+      get => this._expectedBetDenars;
+      set
+      {
+        if (value != this._expectedBetDenars)
+        {
+          this._expectedBetDenars = value;
+          OnPropertyChangedWithValue(value, "ExpectedBetDenars");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string BetOddsText
+    {
+      get => this._betOddsText;
+      set
+      {
+        if (value != this._betOddsText)
+        {
+          this._betOddsText = value;
+          OnPropertyChangedWithValue(value, "BetOddsText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string BettedDenarsText
+    {
+      get => this._bettedDenarsText;
+      set
+      {
+        if (value != this._bettedDenarsText)
+        {
+          this._bettedDenarsText = value;
+          OnPropertyChangedWithValue(value, "BettedDenarsText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string OverallExpectedDenarsText
+    {
+      get => this._overallExpectedDenarsText;
+      set
+      {
+        if (value != this._overallExpectedDenarsText)
+        {
+          this._overallExpectedDenarsText = value;
+          OnPropertyChangedWithValue(value, "OverallExpectedDenarsText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string CurrentExpectedDenarsText
+    {
+      get => this._currentExpectedDenarsText;
+      set
+      {
+        if (value != this._currentExpectedDenarsText)
+        {
+          this._currentExpectedDenarsText = value;
+          OnPropertyChangedWithValue(value, "CurrentExpectedDenarsText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string TotalDenarsText
+    {
+      get => this._totalDenarsText;
+      set
+      {
+        if (value != this._totalDenarsText)
+        {
+          this._totalDenarsText = value;
+          OnPropertyChangedWithValue(value, "TotalDenarsText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string AcceptText
+    {
+      get => this._acceptText;
+      set
+      {
+        if (value != this._acceptText)
+        {
+          this._acceptText = value;
+          OnPropertyChangedWithValue(value, "AcceptText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string CancelText
+    {
+      get => this._cancelText;
+      set
+      {
+        if (value != this._cancelText)
+        {
+          this._cancelText = value;
+          OnPropertyChangedWithValue(value, "CancelText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public bool IsCurrentMatchActive
+    {
+      get => this._isCurrentMatchActive;
+      set
+      {
+        this._isCurrentMatchActive = value;
+        OnPropertyChangedWithValue(value, "IsCurrentMatchActive");
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentMatchVM CurrentMatch
+    {
+      get => this._currentMatch;
+      set
+      {
+        if (value != this._currentMatch)
+        {
+          if (this._currentMatch != null && this._currentMatch.IsValid)
+          {
+            this._currentMatch.State = 2;
+            this._currentMatch.Refresh(false);
+
+            int index = this._rounds.FindIndex(r => r.MatchVMs.Any(m => m.Match == this.Tournament.LastMatch));
+
+            if (index < this.Tournament.Rounds.Length - 1)
+              this._rounds[index + 1].Initialize();
+          }
+
+          this._currentMatch = value;
+          OnPropertyChangedWithValue(value, "CurrentMatch");
+
+          if (this._currentMatch != null)
+            this._currentMatch.State = 1;
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public bool IsTournamentIncomplete => this.Tournament == null || this.Tournament.CurrentMatch != null;
+
+    [DataSourceProperty]
+    public int ActiveRoundIndex
+    {
+      get => this._activeRoundIndex;
+      set
+      {
+        if (value != this._activeRoundIndex)
+        {
+          this.OnNewRoundStarted(this._activeRoundIndex, value);
+          this._activeRoundIndex = value;
+          OnPropertyChangedWithValue(value, "ActiveRoundIndex");
+          this.RefreshBetProperties();
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public bool CanPlayerJoin
+    {
+      get => this._canPlayerJoin;
+      set
+      {
+        if (value != this._canPlayerJoin)
+        {
+          this._canPlayerJoin = value;
+          OnPropertyChangedWithValue(value, "CanPlayerJoin");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public bool HasPrizeItem
+    {
+      get => this._hasPrizeItem;
+      set
+      {
+        if (value != this._hasPrizeItem)
+        {
+          this._hasPrizeItem = value;
+          OnPropertyChangedWithValue(value, "HasPrizeItem");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string JoinTournamentText
+    {
+      get => this._joinTournamentText;
+      set
+      {
+        if (value != this._joinTournamentText)
+        {
+          this._joinTournamentText = value;
+          OnPropertyChangedWithValue(value, "JoinTournamentText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string SkipRoundText
+    {
+      get => this._skipRoundText;
+      set
+      {
+        if (value != this._skipRoundText)
+        {
+          this._skipRoundText = value;
+          OnPropertyChangedWithValue(value, "SkipRoundText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string WatchRoundText
+    {
+      get => this._watchRoundText;
+      set
+      {
+        if (value != this._watchRoundText)
+        {
+          this._watchRoundText = value;
+          OnPropertyChangedWithValue(value, "WatchRoundText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string LeaveText
+    {
+      get => this._leaveText;
+      set
+      {
+        if (value != this._leaveText)
+        {
+          this._leaveText = value;
+          OnPropertyChangedWithValue(value, "LeaveText");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentRoundVM Round1
+    {
+      get => this._round1;
+      set
+      {
+        if (value != this._round1)
+        {
+          this._round1 = value;
+          OnPropertyChangedWithValue(value, "Round1");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentRoundVM Round2
+    {
+      get => this._round2;
+      set
+      {
+        if (value != this._round2)
+        {
+          this._round2 = value;
+          OnPropertyChangedWithValue(value, "Round2");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentRoundVM Round3
+    {
+      get => this._round3;
+      set
+      {
+        if (value != this._round3)
+        {
+          this._round3 = value;
+          OnPropertyChangedWithValue(value, "Round3");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public TeamTournamentRoundVM Round4
+    {
+      get
+      {
+        return this._round4;
+      }
+      set
+      {
+        if (value != this._round4)
+        {
+          this._round4 = value;
+          OnPropertyChangedWithValue(value, "Round4");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public bool InitializationOver
+    {
+      get
+      {
+        return true;
+      }
+    }
+
+    [DataSourceProperty]
+    public string TournamentTitle
+    {
+      get => this._tournamentTitle;
+      set
+      {
+        if (value != this._tournamentTitle)
+        {
+          this._tournamentTitle = value;
+          OnPropertyChangedWithValue(value, "TournamentTitle");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public bool IsOver
+    {
+      get => this._isOver;
+      set
+      {
+        if (this._isOver != value)
+        {
+          this._isOver = value;
+          OnPropertyChangedWithValue(value, "IsOver");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public string WinnerIntro
+    {
+      get => this._winnerIntro;
+      set
+      {
+        if (value != this._winnerIntro)
+        {
+          this._winnerIntro = value;
+          OnPropertyChangedWithValue(value, "WinnerIntro");
+        }
+      }
+    }
+
+    [DataSourceProperty]
+    public MBBindingList<TournamentRewardVM> BattleRewards
+    {
+      get => this._battleRewards;
+      set
+      {
+        if (value != this._battleRewards)
+        {
+          this._battleRewards = value;
+          OnPropertyChangedWithValue(value, "BattleRewards");
+        }
+      }
+    }
+    #endregion view properties
+
+    private readonly List<TeamTournamentRoundVM> _rounds;
+    private int _thisRoundBettedAmount;
+    private bool _isPlayerParticipating;
+    private TeamTournamentRoundVM _round1;
+    private TeamTournamentRoundVM _round2;
+    private TeamTournamentRoundVM _round3;
+    private TeamTournamentRoundVM _round4;
+    private int _activeRoundIndex = -1;
+    private string _joinTournamentText;
+    private string _skipRoundText;
+    private string _watchRoundText;
+    private string _leaveText;
+    private bool _canPlayerJoin;
+    private TeamTournamentMatchVM _currentMatch;
+    private bool _isCurrentMatchActive;
+    private string _betTitleText;
+    private string _betDescriptionText;
+    private string _betOddsText;
+    private string _bettedDenarsText;
+    private string _overallExpectedDenarsText;
+    private string _currentExpectedDenarsText;
+    private string _totalDenarsText;
+    private string _acceptText;
+    private string _cancelText;
+    private string _prizeItemName;
+    private string _tournamentPrizeText;
+    private string _currentWagerText;
+    private int _wageredDenars = -1;
+    private int _expectedBetDenars = -1;
+    private string _betText;
+    private int _maximumBetValue;
+    private string _tournamentWinnerTitle;
+    private TeamTournamentMemberVM _tournamentWinner;
+    private string _tournamentTitle;
+    private bool _isOver;
+    private bool _hasPrizeItem;
+    private string _winnerIntro;
+    private ImageIdentifierVM _prizeVisual;
+    private MBBindingList<TournamentRewardVM> _battleRewards;
+  }
+}

--- a/src/extensions/ReflectionExtensions.cs
+++ b/src/extensions/ReflectionExtensions.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Reflection;
+
+namespace TournamentsEnhanced.extensions
+{
+  /// <summary>
+  /// TAKEN FROM 
+  /// https://stackoverflow.com/questions/1565734/is-it-possible-to-set-private-property-via-reflection/1565766#1565766
+  /// </summary>
+  static class ReflectionExtensions
+  {
+    /// <summary>
+    /// Returns a _private_ Property Value from a given Object. Uses Reflection.
+    /// Throws a ArgumentOutOfRangeException if the Property is not found.
+    /// </summary>
+    /// <typeparam name="T">Type of the Property</typeparam>
+    /// <param name="obj">Object from where the Property Value is returned</param>
+    /// <param name="propName">Propertyname as string.</param>
+    /// <returns>PropertyValue</returns>
+    public static T GetPrivatePropertyValue<T>(this object obj, string propName)
+    {
+      if (obj == null) throw new ArgumentNullException("obj");
+      PropertyInfo pi = obj.GetType().GetProperty(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+      if (pi == null) throw new ArgumentOutOfRangeException("propName", string.Format("Property {0} was not found in Type {1}", propName, obj.GetType().FullName));
+      return (T)pi.GetValue(obj, null);
+    }
+
+    /// <summary>
+    /// Returns a private Property Value from a given Object. Uses Reflection.
+    /// Throws a ArgumentOutOfRangeException if the Property is not found.
+    /// </summary>
+    /// <typeparam name="T">Type of the Property</typeparam>
+    /// <param name="obj">Object from where the Property Value is returned</param>
+    /// <param name="propName">Propertyname as string.</param>
+    /// <returns>PropertyValue</returns>
+    public static T GetPrivateFieldValue<T>(this object obj, string propName)
+    {
+      if (obj == null) throw new ArgumentNullException("obj");
+      Type t = obj.GetType();
+      FieldInfo fi = null;
+      while (fi == null && t != null)
+      {
+        fi = t.GetField(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        t = t.BaseType;
+      }
+      if (fi == null) throw new ArgumentOutOfRangeException("propName", string.Format("Field {0} was not found in Type {1}", propName, obj.GetType().FullName));
+      return (T)fi.GetValue(obj);
+    }
+
+    /// <summary>
+    /// Sets a _private_ Property Value from a given Object. Uses Reflection.
+    /// Throws a ArgumentOutOfRangeException if the Property is not found.
+    /// </summary>
+    /// <typeparam name="T">Type of the Property</typeparam>
+    /// <param name="obj">Object from where the Property Value is set</param>
+    /// <param name="propName">Propertyname as string.</param>
+    /// <param name="val">Value to set.</param>
+    /// <returns>PropertyValue</returns>
+    public static void SetPrivatePropertyValue<T>(this object obj, string propName, T val)
+    {
+      Type t = obj.GetType();
+      if (t.GetProperty(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance) == null)
+        throw new ArgumentOutOfRangeException("propName", string.Format("Property {0} was not found in Type {1}", propName, obj.GetType().FullName));
+      t.InvokeMember(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.SetProperty | BindingFlags.Instance, null, obj, new object[] { val });
+    }
+
+    /// <summary>
+    /// Set a private Property Value on a given Object. Uses Reflection.
+    /// </summary>
+    /// <typeparam name="T">Type of the Property</typeparam>
+    /// <param name="obj">Object from where the Property Value is returned</param>
+    /// <param name="propName">Propertyname as string.</param>
+    /// <param name="val">the value to set</param>
+    /// <exception cref="ArgumentOutOfRangeException">if the Property is not found</exception>
+    public static void SetPrivateFieldValue<T>(this object obj, string propName, T val)
+    {
+      if (obj == null) throw new ArgumentNullException("obj");
+      Type t = obj.GetType();
+      FieldInfo fi = null;
+      while (fi == null && t != null)
+      {
+        fi = t.GetField(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        t = t.BaseType;
+      }
+      if (fi == null) throw new ArgumentOutOfRangeException("propName", string.Format("Field {0} was not found in Type {1}", propName, obj.GetType().FullName));
+      fi.SetValue(obj, val);
+    }
+  }
+}

--- a/src/patches/AddParticipantsPatch.cs
+++ b/src/patches/AddParticipantsPatch.cs
@@ -20,12 +20,12 @@ namespace TournamentsEnhanced
         {
           if (tournamentTeam3.Participants.IsEmpty() && !teamselected)
           {
-            TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement).playerTeam = tournamentTeam3;
+            TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement).PlayerTeam = tournamentTeam3;
             teamselected = true;
           }
           if (TournamentsEnhancedSettings.Instance.BringCompanions &&
-            TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement).playerTeam != null &&
-            TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement).playerTeam.TeamColor == tournamentTeam3.TeamColor &&
+            TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement).PlayerTeam != null &&
+            TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement).PlayerTeam.TeamColor == tournamentTeam3.TeamColor &&
             tournamentTeam3.IsParticipantRequired() &&
             participant.Character.IsHero &&
             (participant.Character.IsPlayerCharacter || participant.Character.HeroObject.IsPlayerCompanion ||
@@ -35,8 +35,8 @@ namespace TournamentsEnhanced
             return false;
           }
           else if (TournamentsEnhancedSettings.Instance.BringCompanions &&
-            TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement).playerTeam != null &&
-            TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement).playerTeam.TeamColor == tournamentTeam3.TeamColor &&
+            TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement).PlayerTeam != null &&
+            TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement).PlayerTeam.TeamColor == tournamentTeam3.TeamColor &&
             !tournamentTeam3.IsParticipantRequired() &&
             participant.Character.IsHero &&
             participant.Character.IsPlayerCharacter)
@@ -47,7 +47,7 @@ namespace TournamentsEnhanced
       }
       foreach (TournamentTeam tournamentTeam in __instance.Teams)
       {
-        if (firstTime && TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement) != null && tournamentTeam.TeamColor == TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement).playerTeam.TeamColor)
+        if (firstTime && TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement) != null && tournamentTeam.TeamColor == TournamentKB.GetTournamentKB(Hero.MainHero.CurrentSettlement).PlayerTeam.TeamColor)
         {
           continue;
         }

--- a/src/patches/TournamentEndMatchPatch.cs
+++ b/src/patches/TournamentEndMatchPatch.cs
@@ -10,10 +10,7 @@ namespace TournamentsEnhanced
   {
     static void Postfix()
     {
-      if (TournamentsEnhancedSettings.Instance.VeryHardTournaments)
-      {
-        CampaignOptions.CombatAIDifficulty = Utilities.difficulty;
-      }
+      Utilities.UnsetDifficulty();
     }
   }
 }

--- a/src/patches/TournamentRenownPatch.cs
+++ b/src/patches/TournamentRenownPatch.cs
@@ -1,4 +1,6 @@
-﻿using HarmonyLib;
+using System;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.SandBox.GameComponents;
 
 namespace TournamentsEnhanced
@@ -9,6 +11,11 @@ namespace TournamentsEnhanced
     static void Postfix(ref int __result)
     {
       __result = TournamentsEnhancedSettings.Instance.RenownReward;
+      if (winner.GetPerkValue(DefaultPerks.OneHanded.Duelist))
+      {
+        // needs to add it, since SecondaryBonus = 1 (for now at least)
+        __result += (int)Math.Round(__result * DefaultPerks.OneHanded.Duelist.SecondaryBonus);
+      }
     }
   }
 }

--- a/src/patches/TournamentRenownPatch.cs
+++ b/src/patches/TournamentRenownPatch.cs
@@ -8,7 +8,7 @@ namespace TournamentsEnhanced
   [HarmonyPatch(typeof(DefaultTournamentModel), "GetRenownReward")]
   class TournamentRenownPatch
   {
-    static void Postfix(ref int __result)
+    static void Postfix(ref int __result, Hero winner)
     {
       __result = TournamentsEnhancedSettings.Instance.RenownReward;
       if (winner.GetPerkValue(DefaultPerks.OneHanded.Duelist))

--- a/src/patches/TournamentStartMatchPatch.cs
+++ b/src/patches/TournamentStartMatchPatch.cs
@@ -7,14 +7,9 @@ namespace TournamentsEnhanced
   [HarmonyPatch(typeof(TournamentMatch), "Start")]
   class TournamentStartMatchPatch
   {
-
     static void Postfix()
     {
-      if (TournamentsEnhancedSettings.Instance.VeryHardTournaments)
-      {
-        Utilities.difficulty = CampaignOptions.CombatAIDifficulty;
-        CampaignOptions.CombatAIDifficulty = CampaignOptions.Difficulty.Realistic;
-      }
+      Utilities.SetDifficulty();
     }
   }
 }

--- a/src/util/Utilities.cs
+++ b/src/util/Utilities.cs
@@ -191,7 +191,25 @@ namespace TournamentsEnhanced
       return new ValueTuple<SkillObject, int>(item, item2);
     }
 
+    public static void SetDifficulty()
+    {
+      if (TournamentsEnhancedSettings.Instance.VeryHardTournaments && difficultyFlag == -1)
+      {
+        difficultyFlag = (short)CampaignOptions.CombatAIDifficulty;
+        CampaignOptions.CombatAIDifficulty = CampaignOptions.Difficulty.Realistic;
+      }
+    }
+
+    public static void UnsetDifficulty()
+    {
+      if (TournamentsEnhancedSettings.Instance.VeryHardTournaments && difficultyFlag > -1)
+      {
+        CampaignOptions.CombatAIDifficulty = (CampaignOptions.Difficulty)difficultyFlag;
+        difficultyFlag = -1;
+      }
+    }
+
     private const int RELATIONSHIP_MODIFIER = 3;
-    public static CampaignOptions.Difficulty difficulty;
+    public static short difficultyFlag = -1;
   }
 }


### PR DESCRIPTION
This PR is about adding a new mode "**TeamTournament**".

- A lot of changes were done, basically a complete new tournament mode was implemented, codebase has tripled :see_no_evil:.
- Adds a new setting to enabe/disable the option for "joining as team"
- Randomized start with up to 32 Teams each up to 8 members (randomized per tournament)
- Uses the Bandit-Camp selection screen for team selection, but with his own VM
- Does not change the basic tournament mode 
- Adds Patches for two functions but only executed if a TeamTournament is selected
- No savegame changes
- Issues still to address : 
  - Does not apply joining of heroes based on tournament type (Lord...) this is a trivial matter and will/can be done shortly
  - Win View is the old one, in general all views are old just with new VMs
  - Right now values for TeamSize, Initial groups etc. are randomized and maybe need adjusting
- I probably will test more and apply fixes on the go.
- As a complete tournament mode is now implemeneted, all changes are possible without patching (mostly)

PS. also fixes #7 