### PR TITLE
Submenu change, Team-Score disappearing mid fight

### DIFF
--- a/src/BehaviorBase.cs
+++ b/src/BehaviorBase.cs
@@ -175,9 +175,9 @@ namespace TournamentsEnhanced
       if (TournamentsEnhancedSettings.Instance.EnableTeamTournaments)
       {
         var teamTournamentMenu = new TeamTournamentTeamSelectionMenu();
-        campaignGameStarter.AddGameMenuOption("town_arena", "participate_as_team", "Join the tournament as a team",
+        campaignGameStarter.AddGameMenuOption("menu_town_tournament_join", "participate_as_team", "Join the tournament as a team",
           new GameMenuOption.OnConditionDelegate(teamTournamentMenu.GameMenuSelectRosterCondition),
-          new GameMenuOption.OnConsequenceDelegate(teamTournamentMenu.GameMenuSelectRosterConsequence), false, 7, false);
+          new GameMenuOption.OnConsequenceDelegate(teamTournamentMenu.GameMenuSelectRosterConsequence), false, 1, false);
       }
     }
 

--- a/src/TeamTournament/TeamTournamentMissionController.cs
+++ b/src/TeamTournament/TeamTournamentMissionController.cs
@@ -214,8 +214,6 @@ namespace TournamentsEnhanced.TeamTournament
       }
     }
 
-    private bool IsTeamDead(TeamTournamentTeam team) => !this._aliveMembers.Any(x => x.Team == team);
-
     private void AddScoreToRemainingTeams() => this._aliveTeams.ForEach(x => x.AddScore(1));
 
     private void AddScoreToKillerTeam(int killerUniqueSeed)
@@ -235,12 +233,13 @@ namespace TournamentsEnhanced.TeamTournament
         var member = this._match.MatchMembers.FirstOrDefault(x => x.IsCharWithDescriptor(affectedAgent.Origin.UniqueSeed));
 
         this._aliveMembers.Remove(member);
+        member.Team.IsAlive = this._aliveMembers.Any(x => x.Team == member.Team);
 
         // apply score only if not on same team
         if (affectedAgent.Team != affectorAgent.Team)
           this.AddScoreToKillerTeam(affectorAgent.Origin.UniqueSeed);
 
-        if (this.IsTeamDead(member.Team))
+        if (!member.Team.IsAlive)
         {
           this._aliveTeams.Remove(member.Team);
 
@@ -372,8 +371,9 @@ namespace TournamentsEnhanced.TeamTournament
         {
           simAttacks.Remove(nextFighter);
           this._aliveMembers.Remove(nextFighter);
+          nextFighter.Team.IsAlive = this._aliveMembers.Any(x => x.Team == nextFighter.Team);
 
-          if (this.IsTeamDead(nextFighter.Team))
+          if (!nextFighter.Team.IsAlive)
           {
             this._aliveTeams.Remove(nextFighter.Team);
             this.AddScoreToRemainingTeams();

--- a/src/TeamTournament/TeamTournamentTeam.cs
+++ b/src/TeamTournament/TeamTournamentTeam.cs
@@ -15,6 +15,7 @@ namespace TournamentsEnhanced.TeamTournament
     public Banner TeamBanner { get; set; }
     public uint TeamColor { get; set; }
     public bool IsPlayerTeam => this.Members.Any(x => x.IsPlayer);
+    public bool IsAlive { get; internal set; }
 
     public TeamTournamentTeam(IEnumerable<TeamTournamentMember> members, Banner teamBanner = null, uint teamColor = 0, TeamTournamentMember leader = null)
     {

--- a/src/TeamTournament/ViewModels/TeamTournamentVM.cs
+++ b/src/TeamTournament/ViewModels/TeamTournamentVM.cs
@@ -178,7 +178,7 @@ namespace TournamentsEnhanced.TeamTournament.ViewModels
 
         if (this._isPlayerParticipating)
         {
-          GameTexts.SetVariable("TOURNAMENT_ELIMINATED_ROUND", this.Tournament.PlayerTeamLostAtRound + 1);
+          GameTexts.SetVariable("TOURNAMENT_ELIMINATED_ROUND", this.Tournament.PlayerTeamLostAtRound);
           this.WinnerIntro = GameTexts.FindText("str_tournament_result_eliminated", null).ToString();
         }
         else
@@ -199,9 +199,9 @@ namespace TournamentsEnhanced.TeamTournament.ViewModels
     {
       if (this.IsCurrentMatchActive && agent.IsHuman)
       {
-        var member = GetMemberForSeed(agent.Origin.UniqueSeed);
-        if (member != null)
-          member.IsDead = true;
+        var team = _currentMatch.Teams.First(x => x.Team.Members.Any(m => m.Descriptor.CompareTo(agent.Origin.UniqueSeed) == 0));
+        if (!team.Team.IsAlive)
+          team.GetTeamLeader().IsDead = true;
       }
     }
 


### PR DESCRIPTION
This PR moves the "join as team" menu entry to the "menu_town_tournament_join" menu.
Also fixes a small bug that caused team score to disappear when the team leader was killed.